### PR TITLE
fix Compilation on Linux fail - MbapAttenuationConfig struct instance…

### DIFF
--- a/Source/sg_AudioStructs.hpp
+++ b/Source/sg_AudioStructs.hpp
@@ -131,7 +131,7 @@ struct AudioConfig {
     tl::optional<float> pinkNoiseGain{};
 
     // MBAP-specific
-    MbapAttenuationConfig MbapAttenuationConfig{};
+    MbapAttenuationConfig mbapAttenuationConfig{};
 };
 
 //==============================================================================

--- a/Source/sg_LogicStrucs.cpp
+++ b/Source/sg_LogicStrucs.cpp
@@ -910,7 +910,7 @@ std::unique_ptr<AudioConfig> SpatGrisData::toAudioConfig() const
     auto const shouldProcessAttenuation{ !appData.playerExists
                                          && project.mbapDistanceAttenuationData.attenuationBypassState
                                                 == AttenuationBypassSate::off };
-    result->MbapAttenuationConfig
+    result->mbapAttenuationConfig
         = project.mbapDistanceAttenuationData.toConfig(appData.audioSettings.sampleRate, shouldProcessAttenuation);
     result->masterGain = project.masterGain.toGain();
     result->pinkNoiseGain = pinkNoiseLevel.map([](auto const & level) { return level.toGain(); });

--- a/Source/sg_MbapSpatAlgorithm.cpp
+++ b/Source/sg_MbapSpatAlgorithm.cpp
@@ -115,8 +115,8 @@ void MbapSpatAlgorithm::process(AudioConfig const & config,
 
         // process attenuation if Player does not exist
         auto * inputSamples{ sourceBuffer[source.key].getWritePointer(0) };
-        if (config.MbapAttenuationConfig.shouldProcess) {
-            config.MbapAttenuationConfig.process(inputSamples,
+        if (config.mbapAttenuationConfig.shouldProcess) {
+            config.mbapAttenuationConfig.process(inputSamples,
                                                  numSamples,
                                                  spatData.mbapSourceDistance,
                                                  data.attenuationState);


### PR DESCRIPTION
Fixes #422 

Fixes Compilation on Linux fail - MbapAttenuationConfig struct instance name problem.

Files changed:

[Source/sg_AudioStructs.hpp](https://github.com/edumeneses/SpatGRIS/blob/c7a2d0ac7efef402863f0fb033c017b0923ad5b2/Source/sg_AudioStructs.hpp#L134) line 134:

```
MbapAttenuationConfig mbapAttenuationConfig{};
```

[Source/sg_LogicStrucs.cpp](https://github.com/edumeneses/SpatGRIS/blob/c7a2d0ac7efef402863f0fb033c017b0923ad5b2/Source/sg_LogicStrucs.cpp#L913) line 913:

```
result->mbapAttenuationConfig
```

[Source/sg_MbapSpatAlgorithm.cpp](https://github.com/edumeneses/SpatGRIS/blob/c7a2d0ac7efef402863f0fb033c017b0923ad5b2/Source/sg_MbapSpatAlgorithm.cpp#L118) lines 118-119:

```
        if (config.mbapAttenuationConfig.shouldProcess) {
            config.mbapAttenuationConfig.process(inputSamples,
```