### PR TITLE
Make the build pipeline execute on all available cpu cores instead of 8

### DIFF
--- a/.github/workflows/SpatGris-builds.yml
+++ b/.github/workflows/SpatGris-builds.yml
@@ -48,7 +48,7 @@ jobs:
         run: cd JUCE && ./Projucer --resave ../SpatGRIS.jucer
 
       - name: Compile SpatGRIS
-        run: cd Builds/LinuxMakefile && make CXX=clang++-18 CONFIG=Release -j 8
+        run: cd Builds/LinuxMakefile && make CXX=clang++-18 CONFIG=Release -j$(nproc)
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The pipeline used 8 cores. I don't know if there was a very good reason for this but `nproc` should be at least no worse than hardcoding the value.