### PR TITLE
Send SpeakerView the center position of the speakers that are in a group

### DIFF
--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2071,9 +2071,9 @@ void MainContentComponent::speakerOutputPatchChanged(output_patch_t const oldOut
     refreshSpeakerSlices();
 }
 
-std::map<int, tl::optional<Position>> MainContentComponent::getSpeakersGroupCenters()
+std::map<output_patch_t, tl::optional<Position>> MainContentComponent::getSpeakersGroupCenters()
 {
-  std::map<int, tl::optional<Position>> speaker_group_center{};
+  std::map<output_patch_t, tl::optional<Position>> speaker_group_center{};
   mData.speakerSetup.speakerSetupValueTree;
   // the first child is the main speaker group where individual speakers and speaker groups are stored.
   auto main_speaker_group = mData.speakerSetup.speakerSetupValueTree.getChild(0);
@@ -2087,12 +2087,13 @@ std::map<int, tl::optional<Position>> MainContentComponent::getSpeakersGroupCent
         Position center_position = juce::VariantConverter<Position>::fromVar(sub_group[CARTESIAN_POSITION]);
         for (int j = 0; j < sub_group.getNumChildren(); j++) {
           auto speaker = sub_group.getChild(j);
-          int speaker_patch_id = juce::VariantConverter<int>::fromVar(speaker[SPEAKER_PATCH_ID]);
+          auto const speaker_patch_id = output_patch_t{speaker[SPEAKER_PATCH_ID]};
+          //int speaker_patch_id = juce::VariantConverter<int>::fromVar(speaker[SPEAKER_PATCH_ID]);
           speaker_group_center[speaker_patch_id] = center_position;
         }
         // if the node is not a group it's a speaker and we don't care. If its id matches, return its position.
       } else {
-        int speaker_patch_id = juce::VariantConverter<int>::fromVar(node[SPEAKER_PATCH_ID]);
+        auto const speaker_patch_id = output_patch_t{node[SPEAKER_PATCH_ID]};
         speaker_group_center[speaker_patch_id] = tl::nullopt;
       }
   }

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2088,7 +2088,6 @@ std::map<output_patch_t, tl::optional<Position>> MainContentComponent::getSpeake
         for (int j = 0; j < sub_group.getNumChildren(); j++) {
           auto speaker = sub_group.getChild(j);
           auto const speaker_patch_id = output_patch_t{speaker[SPEAKER_PATCH_ID]};
-          //int speaker_patch_id = juce::VariantConverter<int>::fromVar(speaker[SPEAKER_PATCH_ID]);
           speaker_group_center[speaker_patch_id] = center_position;
         }
         // if the node is not a group it's a speaker and we don't care. If its id matches, return its position.

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -19,6 +19,7 @@
 
 #include "sg_MainComponent.hpp"
 
+#include <map>
 #include "sg_AudioManager.hpp"
 #include "AlgoGRIS/Data/sg_CommandId.hpp"
 #include "sg_ControlPanel.hpp"
@@ -29,6 +30,7 @@
 #include "sg_ScopeGuard.hpp"
 #include "sg_TitledComponent.hpp"
 #include "AlgoGRIS/Data/sg_constants.hpp"
+#include "AlgoGRIS/StructGRIS/ValueTreeUtilities.hpp"
 #include "Misc/sg_DefaultFiles.hpp"
 
 namespace gris
@@ -2067,6 +2069,35 @@ void MainContentComponent::speakerOutputPatchChanged(output_patch_t const oldOut
 
     refreshSourceSlices();
     refreshSpeakerSlices();
+}
+
+std::map<int, tl::optional<Position>> MainContentComponent::getSpeakersGroupCenters()
+{
+  std::map<int, tl::optional<Position>> speaker_group_center{};
+  mData.speakerSetup.speakerSetupValueTree;
+  // the first child is the main speaker group where individual speakers and speaker groups are stored.
+  auto main_speaker_group = mData.speakerSetup.speakerSetupValueTree.getChild(0);
+  for (int i = 0; i < main_speaker_group.getNumChildren(); i++)
+  {
+      auto node = main_speaker_group.getChild(i);
+      // if the node is a speakergroup, search all the group for a child
+      // that has the right id and return the Position of the group.
+      if (node.getType () == SPEAKER_GROUP) {
+        auto sub_group = node;
+        Position center_position = juce::VariantConverter<Position>::fromVar(sub_group[CARTESIAN_POSITION]);
+        for (int j = 0; j < main_speaker_group.getNumChildren(); j++) {
+          auto speaker = sub_group.getChild(j);
+          int speaker_patch_id = juce::VariantConverter<int>::fromVar(speaker[SPEAKER_PATCH_ID]);
+          speaker_group_center[speaker_patch_id] = center_position;
+        }
+        // if the node is not a group it's a speaker and we don't care. If its id matches, return its position.
+      } else {
+        int speaker_patch_id = juce::VariantConverter<int>::fromVar(node[SPEAKER_PATCH_ID]);
+        speaker_group_center[speaker_patch_id] = tl::nullopt;
+      }
+  }
+  // if for some reason the speaker wasn't found, just return a 0,0,0 position
+  return speaker_group_center;
 }
 
 //==============================================================================

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2096,7 +2096,6 @@ std::map<output_patch_t, tl::optional<Position>> MainContentComponent::getSpeake
         speaker_group_center[speaker_patch_id] = tl::nullopt;
       }
   }
-  // if for some reason the speaker wasn't found, just return a 0,0,0 position
   return speaker_group_center;
 }
 

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2085,7 +2085,7 @@ std::map<int, tl::optional<Position>> MainContentComponent::getSpeakersGroupCent
       if (node.getType () == SPEAKER_GROUP) {
         auto sub_group = node;
         Position center_position = juce::VariantConverter<Position>::fromVar(sub_group[CARTESIAN_POSITION]);
-        for (int j = 0; j < main_speaker_group.getNumChildren(); j++) {
+        for (int j = 0; j < sub_group.getNumChildren(); j++) {
           auto speaker = sub_group.getChild(j);
           int speaker_patch_id = juce::VariantConverter<int>::fromVar(speaker[SPEAKER_PATCH_ID]);
           speaker_group_center[speaker_patch_id] = center_position;

--- a/Source/sg_MainComponent.hpp
+++ b/Source/sg_MainComponent.hpp
@@ -171,6 +171,13 @@ public:
 
     void speakerDirectOutOnlyChanged(output_patch_t outputPatch, bool state);
     void speakerOutputPatchChanged(output_patch_t oldOutputPatch, output_patch_t newOutputPatch);
+
+    /**
+     * Gets a speaker's central group coordinate. If the speaker is an individual speaker, returns its position.
+     * Right now this is used to send the center of a group to SpeakerView to better orient groups.
+     */
+    std::map<int, tl::optional<Position>> getSpeakersGroupCenters();
+
     void setSpeakerGain(output_patch_t outputPatch, dbfs_t gain);
     void setSpeakerHighPassFreq(output_patch_t outputPatch, hz_t freq);
     void setOscPort(int newOscPort);
@@ -295,6 +302,8 @@ public:
 
     bool speakerViewShouldGrabFocus();
     void resetSpeakerViewShouldGrabFocus();
+
+
 
 private:
     //==============================================================================

--- a/Source/sg_MainComponent.hpp
+++ b/Source/sg_MainComponent.hpp
@@ -173,8 +173,9 @@ public:
     void speakerOutputPatchChanged(output_patch_t oldOutputPatch, output_patch_t newOutputPatch);
 
     /**
-     * Gets a speaker's central group coordinate. If the speaker is an individual speaker, returns its position.
-     * Right now this is used to send the center of a group to SpeakerView to better orient groups.
+     * Gets a map of <speaker output patch id> -> <optional speaker group center position>
+     * Basically this associates every speaker id with the center position of its parent group or with
+     * nullopt if its not part of a group.
      */
     std::map<int, tl::optional<Position>> getSpeakersGroupCenters();
 

--- a/Source/sg_MainComponent.hpp
+++ b/Source/sg_MainComponent.hpp
@@ -177,8 +177,8 @@ public:
      * Basically this associates every speaker id with the center position of its parent group or with
      * nullopt if its not part of a group.
      */
-    std::map<int, tl::optional<Position>> getSpeakersGroupCenters();
-
+    std::map<output_patch_t, tl::optional<Position>> getSpeakersGroupCenters();
+    
     void setSpeakerGain(output_patch_t outputPatch, dbfs_t gain);
     void setSpeakerHighPassFreq(output_patch_t outputPatch, hz_t freq);
     void setOscPort(int newOscPort);

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -273,7 +273,7 @@ void SpeakerViewComponent::prepareSpeakersJson()
 
             // This will insert a default tl::nullopt if the key is not in
             // the map. In this case we can live with it.
-            auto center_position = speaker_centers[speaker.key.get()];
+            auto center_position = speaker_centers[speaker.key];
 
             if (center_position) {
               auto const & center_cartesion_pos = center_position->getCartesian();

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -270,10 +270,13 @@ void SpeakerViewComponent::prepareSpeakersJson()
             mJsonSpeakers += ",";
             appendNumber(mJsonSpeakers, getAlpha());
             // if the speaker is in a group, add its center's position.
-            auto center_position = speaker_centers.at(speaker.key.get());
+
+            // This will insert a default tl::nullopt if the key is not in
+            // the map. In this case we can live with it.
+            auto center_position = speaker_centers[speaker.key.get()];
+
             if (center_position) {
               auto const & center_cartesion_pos = center_position->getCartesian();
-              std::cout << center_cartesion_pos.toString() << std::endl;
               mJsonSpeakers += ",[";
               appendNumber(mJsonSpeakers, center_cartesion_pos.x);
               mJsonSpeakers += ",";

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -226,6 +226,7 @@ void SpeakerViewComponent::prepareSpeakersJson()
     mJsonSpeakers.clear();
     mJsonSpeakers.reserve(4096);
     mJsonSpeakers += "[\"speakers\",";
+    auto speaker_centers = mMainContentComponent.getSpeakersGroupCenters();
     if (viewSettings.showSpeakers) {
         for (auto const & speaker : mData.warmData.speakers) {
             static constexpr auto DEFAULT_ALPHA = 0.75f;
@@ -249,6 +250,7 @@ void SpeakerViewComponent::prepareSpeakersJson()
                 isSelected
                 isDirectOutOnly
                 alpha
+                (group center position (if speaker is in a group))
             */
 
             auto const & pos{ speaker.value.position.getCartesian() };
@@ -267,6 +269,19 @@ void SpeakerViewComponent::prepareSpeakersJson()
             mJsonSpeakers += speaker.value.isDirectOutOnly ? "1" : "0";
             mJsonSpeakers += ",";
             appendNumber(mJsonSpeakers, getAlpha());
+            // if the speaker is in a group, add its center's position.
+            auto center_position = speaker_centers.at(speaker.key.get());
+            if (center_position) {
+              auto const & center_cartesion_pos = center_position->getCartesian();
+              std::cout << center_cartesion_pos.toString() << std::endl;
+              mJsonSpeakers += ",[";
+              appendNumber(mJsonSpeakers, center_cartesion_pos.x);
+              mJsonSpeakers += ",";
+              appendNumber(mJsonSpeakers, center_cartesion_pos.y);
+              mJsonSpeakers += ",";
+              appendNumber(mJsonSpeakers, center_cartesion_pos.z);
+              mJsonSpeakers += "]";
+            }
             mJsonSpeakers += "],";
 
             processedSpeakers++;


### PR DESCRIPTION
This optionally adds a field to the json array that is sent the SpeakerView to indicate the center of the group that a speaker is a part of.

If a speaker is not part of a group, the json array does not include that field.