### PR TITLE
Fix bug where SpatGRIS didn't listen to speakerview's keyboard shortcuts

### DIFF
--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2356,7 +2356,6 @@ void MainContentComponent::refreshViewportConfig() const
     if (!mAudioProcessor) {
         return;
     }
-
     auto const & spatAlgorithm{ *mAudioProcessor->getSpatAlgorithm() };
 
     auto const newConfig{ mData.toViewportConfig() };

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -433,10 +433,10 @@ void SpeakerViewComponent::listenUDP()
                 const auto keys = jsonResult.getDynamicObject()->getProperties();
 
                 for (int i{}; i < keys.size(); ++i) {
-                    auto & property = keys.getName(i).toString();
+                    std::string property = keys.getName(i).toString().toStdString();
                     juce::var value = keys.getValueAt(i);
 
-                    if (property.compare(juce::String("selSpkNum")) == 0) {
+                    if (property == "selSpkNum") {
                         juce::String selSpkNumValues = value;
                         auto spkIsSelectedWithMouseStr = selSpkNumValues.fromLastOccurrenceOf(",", false, true);
                         selSpkNumValues = selSpkNumValues.dropLastCharacters(spkIsSelectedWithMouseStr.length() + 1);
@@ -450,77 +450,77 @@ void SpeakerViewComponent::listenUDP()
                                 mMainContentComponent.setSelectedSpeakers(juce::Array<output_patch_t>{ speaker });
                             });
                         }
-                    } else if (property.compare(juce::String("keepSVTop")) == 0) {
+                    } else if (property == "keepSVTop") {
                         auto keepSVOnTopValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, keepSVOnTopValue] {
                             mMainContentComponent.handleKeepSVOnTopFromSpeakerView(keepSVOnTopValue);
                         });
-                    } else if (property.compare(juce::String("showHall")) == 0) {
+                    } else if (property == "showHall") {
                         auto showHallValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showHallValue] {
                             mMainContentComponent.handleShowHallFromSpeakerView(showHallValue);
                         });
-                    } else if (property.compare(juce::String("showSrcNum")) == 0) {
+                    } else if (property == "showSrcNum") {
                         auto showSrcValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSrcValue] {
                             mMainContentComponent.handleShowSourceNumbersFromSpeakerView(showSrcValue);
                         });
-                    } else if (property.compare(juce::String("showSpkNum")) == 0) {
+                    } else if (property == "showSpkNum") {
                         auto showSpkValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpkValue] {
                             mMainContentComponent.handleShowSpeakerNumbersFromSpeakerView(showSpkValue);
                         });
-                    } else if (property.compare(juce::String("showSpks")) == 0) {
+                    } else if (property == "showSpks") {
                         auto showSpksValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpksValue] {
                             mMainContentComponent.handleShowSpeakersFromSpeakerView(showSpksValue);
                         });
-                    } else if (property.compare(juce::String("showSpkTriplets")) == 0) {
+                    } else if (property == "showSpkTriplets") {
                         auto showSpksTripletsValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpksTripletsValue] {
                             mMainContentComponent.handleShowSpeakerTripletsFromSpeakerView(showSpksTripletsValue);
                         });
-                    } else if (property.compare(juce::String("showSrcActivity")) == 0) {
+                    } else if (property == "showSrcActivity") {
                         auto showSrcActivityValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSrcActivityValue] {
                             mMainContentComponent.handleShowSourceActivityFromSpeakerView(showSrcActivityValue);
                         });
-                    } else if (property.compare(juce::String("showSpkLevel")) == 0) {
+                    } else if (property == "showSpkLevel") {
                         auto showSpkLevelValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpkLevelValue] {
                             mMainContentComponent.handleShowSpeakerLevelFromSpeakerView(showSpkLevelValue);
                         });
-                    } else if (property.compare(juce::String("showSphereCube")) == 0) {
+                    } else if (property == "showSphereCube") {
                         auto showSphereOrCubeValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSphereOrCubeValue] {
                             mMainContentComponent.handleShowSphereOrCubeFromSpeakerView(showSphereOrCubeValue);
                         });
-                    } else if (property.compare(juce::String("resetSrcPos")) == 0) {
+                    } else if (property == "resetSrcPos") {
                         if (static_cast<int>(value) != 0) {
                             juce::MessageManager::callAsync(
                                 [this] { mMainContentComponent.handleResetSourcesPositionsFromSpeakerView(); });
                         }
-                    } else if (property.compare(juce::String("genMute")) == 0) {
+                    } else if (property == "genMute") {
                         auto generalMute = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, generalMute] {
                             mMainContentComponent.handleGeneralMuteFromSpeakerView(generalMute);
                         });
-                    } else if (property.compare(juce::String("winPos")) == 0) {
+                    } else if (property == "winPos") {
                         auto winPosValue = value;
                         juce::MessageManager::callAsync([this, winPosValue] {
                             mMainContentComponent.handleWindowPositionFromSpeakerView(winPosValue);
                         });
-                    } else if (property.compare(juce::String("winSize")) == 0) {
+                    } else if (property == "winSize") {
                         auto winSizeValue = value;
                         juce::MessageManager::callAsync([this, winSizeValue] {
                             mMainContentComponent.handleWindowSizeFromSpeakerView(winSizeValue);
                         });
-                    } else if (property.compare(juce::String("camPos")) == 0) {
+                    } else if (property == "camPos") {
                         auto camPosValue = value;
                         juce::MessageManager::callAsync([this, camPosValue] {
                             mMainContentComponent.handleCameraPositionFromSpeakerView(camPosValue);
                         });
-                    } else if (property.compare(juce::String("quitting")) == 0) {
+                    } else if (property == "quitting") {
                         bool quittingValue = value;
                         if (quittingValue) {
                             stopTimer();

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -433,7 +433,7 @@ void SpeakerViewComponent::listenUDP()
                 const auto keys = jsonResult.getDynamicObject()->getProperties();
 
                 for (int i{}; i < keys.size(); ++i) {
-                    auto property = keys.getName(i).toString();
+                    const auto property = keys.getName(i).toString();
                     juce::var value = keys.getValueAt(i);
 
                     if (property == "selSpkNum") {

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -433,7 +433,7 @@ void SpeakerViewComponent::listenUDP()
                 const auto keys = jsonResult.getDynamicObject()->getProperties();
 
                 for (int i{}; i < keys.size(); ++i) {
-                    std::string property = keys.getName(i).toString().toStdString();
+                    auto property = keys.getName(i).toString();
                     juce::var value = keys.getValueAt(i);
 
                     if (property == "selSpkNum") {

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -433,10 +433,9 @@ void SpeakerViewComponent::listenUDP()
                 const auto keys = jsonResult.getDynamicObject()->getProperties();
 
                 for (int i{}; i < keys.size(); ++i) {
-                    const auto property = keys.getName(i).toString();
+                    auto const property = keys.getName(i);
                     juce::var value = keys.getValueAt(i);
-
-                    if (property == "selSpkNum") {
+                    if (property == selSpkNum) {
                         juce::String selSpkNumValues = value;
                         auto spkIsSelectedWithMouseStr = selSpkNumValues.fromLastOccurrenceOf(",", false, true);
                         selSpkNumValues = selSpkNumValues.dropLastCharacters(spkIsSelectedWithMouseStr.length() + 1);
@@ -450,77 +449,77 @@ void SpeakerViewComponent::listenUDP()
                                 mMainContentComponent.setSelectedSpeakers(juce::Array<output_patch_t>{ speaker });
                             });
                         }
-                    } else if (property == "keepSVTop") {
+                    } else if (property == keepSVTop) {
                         auto keepSVOnTopValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, keepSVOnTopValue] {
                             mMainContentComponent.handleKeepSVOnTopFromSpeakerView(keepSVOnTopValue);
                         });
-                    } else if (property == "showHall") {
+                    } else if (property == showHall) {
                         auto showHallValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showHallValue] {
                             mMainContentComponent.handleShowHallFromSpeakerView(showHallValue);
                         });
-                    } else if (property == "showSrcNum") {
+                    } else if (property == showSrcNum) {
                         auto showSrcValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSrcValue] {
                             mMainContentComponent.handleShowSourceNumbersFromSpeakerView(showSrcValue);
                         });
-                    } else if (property == "showSpkNum") {
+                    } else if (property == showSpkNum) {
                         auto showSpkValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpkValue] {
                             mMainContentComponent.handleShowSpeakerNumbersFromSpeakerView(showSpkValue);
                         });
-                    } else if (property == "showSpks") {
+                    } else if (property == showSpks) {
                         auto showSpksValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpksValue] {
                             mMainContentComponent.handleShowSpeakersFromSpeakerView(showSpksValue);
                         });
-                    } else if (property == "showSpkTriplets") {
+                    } else if (property == showSpkTriplets) {
                         auto showSpksTripletsValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpksTripletsValue] {
                             mMainContentComponent.handleShowSpeakerTripletsFromSpeakerView(showSpksTripletsValue);
                         });
-                    } else if (property == "showSrcActivity") {
+                    } else if (property == showSrcActivity) {
                         auto showSrcActivityValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSrcActivityValue] {
                             mMainContentComponent.handleShowSourceActivityFromSpeakerView(showSrcActivityValue);
                         });
-                    } else if (property == "showSpkLevel") {
+                    } else if (property == showSpkLevel) {
                         auto showSpkLevelValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSpkLevelValue] {
                             mMainContentComponent.handleShowSpeakerLevelFromSpeakerView(showSpkLevelValue);
                         });
-                    } else if (property == "showSphereCube") {
+                    } else if (property == showSphereCube) {
                         auto showSphereOrCubeValue = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, showSphereOrCubeValue] {
                             mMainContentComponent.handleShowSphereOrCubeFromSpeakerView(showSphereOrCubeValue);
                         });
-                    } else if (property == "resetSrcPos") {
+                    } else if (property == resetSrcPos) {
                         if (static_cast<int>(value) != 0) {
                             juce::MessageManager::callAsync(
                                 [this] { mMainContentComponent.handleResetSourcesPositionsFromSpeakerView(); });
                         }
-                    } else if (property == "genMute") {
+                    } else if (property == genMute) {
                         auto generalMute = static_cast<bool>(value);
                         juce::MessageManager::callAsync([this, generalMute] {
                             mMainContentComponent.handleGeneralMuteFromSpeakerView(generalMute);
                         });
-                    } else if (property == "winPos") {
+                    } else if (property == winPos) {
                         auto winPosValue = value;
                         juce::MessageManager::callAsync([this, winPosValue] {
                             mMainContentComponent.handleWindowPositionFromSpeakerView(winPosValue);
                         });
-                    } else if (property == "winSize") {
+                    } else if (property == winSize) {
                         auto winSizeValue = value;
                         juce::MessageManager::callAsync([this, winSizeValue] {
                             mMainContentComponent.handleWindowSizeFromSpeakerView(winSizeValue);
                         });
-                    } else if (property == "camPos") {
+                    } else if (property == camPos) {
                         auto camPosValue = value;
                         juce::MessageManager::callAsync([this, camPosValue] {
                             mMainContentComponent.handleCameraPositionFromSpeakerView(camPosValue);
                         });
-                    } else if (property == "quitting") {
+                    } else if (property == quitting) {
                         bool quittingValue = value;
                         if (quittingValue) {
                             stopTimer();

--- a/Source/sg_SpeakerViewComponent.hpp
+++ b/Source/sg_SpeakerViewComponent.hpp
@@ -67,6 +67,31 @@ public:
     static constexpr auto SPHERE_RADIUS = 0.03f;
     static constexpr auto HALF_SPHERE_RADIUS = SPHERE_RADIUS / 2.0f;
     static inline const juce::String localhost{"127.0.0.1"};
+
+
+/**
+ * @brief This macro creates a `juce::Identifier` variable with the same name as its string content,
+ * reducing boilerplate and ensuring consistency between the variable name and its value.
+ */
+#define MAKE_IDENTIFIER(name) static inline const juce::Identifier name{ #name };
+    MAKE_IDENTIFIER(selSpkNum)
+    MAKE_IDENTIFIER(keepSVTop)
+    MAKE_IDENTIFIER(showHall)
+    MAKE_IDENTIFIER(showSrcNum)
+    MAKE_IDENTIFIER(showSpkNum)
+    MAKE_IDENTIFIER(showSpks)
+    MAKE_IDENTIFIER(showSpkTriplets)
+    MAKE_IDENTIFIER(showSrcActivity)
+    MAKE_IDENTIFIER(showSpkLevel)
+    MAKE_IDENTIFIER(showSphereCube)
+    MAKE_IDENTIFIER(resetSrcPos)
+    MAKE_IDENTIFIER(genMute)
+    MAKE_IDENTIFIER(winPos)
+    MAKE_IDENTIFIER(winSize)
+    MAKE_IDENTIFIER(camPos)
+    MAKE_IDENTIFIER(quitting)
+#undef MAKE_IDENTIFIER
+
   //==============================================================================
     explicit SpeakerViewComponent(MainContentComponent & mainContentComponent);
 


### PR DESCRIPTION
Basically, the only thing that SpatGRIS was listening to was the selected speaker because the string evaluation with compare was always returning true.

I fixed the bug simply by changing the `juce::String` with an `std::string` and the `compare` function with `==`.

This is Weird(tm)

To test this, try the show hall shortcut in SpeakerView (alt+h). It should now work whereas it uses to instantly revert to not showing the hall­.