### PR TITLE
Don't stop sending UDP when SpeakerView quits

### DIFF
--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2074,7 +2074,6 @@ void MainContentComponent::speakerOutputPatchChanged(output_patch_t const oldOut
 std::map<output_patch_t, tl::optional<Position>> MainContentComponent::getSpeakersGroupCenters()
 {
   std::map<output_patch_t, tl::optional<Position>> speaker_group_center{};
-  mData.speakerSetup.speakerSetupValueTree;
   // the first child is the main speaker group where individual speakers and speaker groups are stored.
   auto main_speaker_group = mData.speakerSetup.speakerSetupValueTree.getChild(0);
   for (int i = 0; i < main_speaker_group.getNumChildren(); i++)

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -536,12 +536,6 @@ void SpeakerViewComponent::listenUDP()
                         juce::MessageManager::callAsync([this, camPosValue] {
                             mMainContentComponent.handleCameraPositionFromSpeakerView(camPosValue);
                         });
-                    } else if (property == quitting) {
-                        bool quittingValue = value;
-                        if (quittingValue) {
-                            stopTimer();
-                            emptyUDPReceiverBuffer();
-                        }
                     }
                 }
             }


### PR DESCRIPTION
I think this behavior was instated when the JSON-UDP part of spatGRIS took a lot of cpu cycles but it makes it hard to use SpatGRIS with a standalone SpeakerView. Now that sending and receiving udp is only a small part (<1% when profiled with this change) of the runtime of the software, I think we can afford sending packets even if we don't know for sure that a SpeakerView is listening.