### PR TITLE
Fix Some Speaker Setup Window UX Regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,13 @@ WindowsInstallerOutput
 # Mac OS Desktop Services Store files
 *.DS_Store
 
+# Cache
+.cache
+
+# emacs
+.dir-locals.el
+.projectile
+
 #########################
 # .gitignore file for Xcode4 and Xcode5 Source projects
 #
@@ -63,7 +70,7 @@ WindowsInstallerOutput
 
 #
 # *.lock - this is used and abused by many editors for many different things.
-#    For the main ones I use (e.g. Eclipse), it should be excluded 
+#    For the main ones I use (e.g. Eclipse), it should be excluded
 #    from source-control, but YMMV.
 #   (lock files are usually local-only file-synchronization on the local FS that should NOT go in git)
 # c.f. the "OPTIONAL" section at bottom though, for tool-specific variations!
@@ -79,7 +86,7 @@ WindowsInstallerOutput
 
 ####
 # Xcode temporary files that should never be committed
-# 
+#
 # NB: NIB/XIB files still exist even on Storyboard projects, so we want this...
 
 *~.nib
@@ -224,7 +231,7 @@ xcuserdata/
 # IDEA:
 #
 # c.f. https://www.jetbrains.com/objc/help/managing-projects-under-version-control.html?search=workspace.xml
-# 
+#
 #.idea/workspace.xml
 #
 # TEXTMATE:

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
@@ -36,7 +36,7 @@ SpeakerSetupContainer::SpeakerSetupContainer(const juce::File & speakerSetupXmlF
     speakerSetupTreeView.setDefaultOpenness (true);
     speakerSetupTreeView.setMultiSelectEnabled (true);
 
-    mainSpeakerGroupLine = std::make_unique<SpeakerSetupLine> (speakerSetupVt.getChild(0), undoManager, onSelectionChanged);
+    mainSpeakerGroupLine = std::make_unique<SpeakerSetupLine> (speakerSetupVt.getChild(0), undoManager, onSelectionChanged, speakerSetupTreeView);
     speakerSetupTreeView.setRootItem (mainSpeakerGroupLine.get ());
 
     auto setLabelText = [this](juce::Label& label, const juce::String & text) {
@@ -75,7 +75,8 @@ void SpeakerSetupContainer::reload(juce::ValueTree theSpeakerSetupVt)
 {
     speakerSetupVt = theSpeakerSetupVt;
     speakerSetupTreeView.setRootItem (nullptr);
-    mainSpeakerGroupLine.reset (new SpeakerSetupLine (speakerSetupVt.getChild(0), undoManager, onSelectionChanged));
+    auto opennessState = std::move(mainSpeakerGroupLine->opennessState);
+    mainSpeakerGroupLine.reset(new SpeakerSetupLine (speakerSetupVt.getChild(0), undoManager, onSelectionChanged, speakerSetupTreeView, std::move(opennessState)));
     speakerSetupTreeView.setRootItem (mainSpeakerGroupLine.get ());
 }
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "SpeakerSetupLine.hpp"
+#include "SpeakerSetupTreeView.hpp"
 #include <Data/sg_LogicStrucs.hpp>
 #include <StructGRIS/ValueTreeUtilities.hpp>
 
@@ -78,6 +79,7 @@ public:
     void setSpatMode(SpatMode spatMode) { speakerSetupVt.setProperty(SPAT_MODE, spatModeToString(spatMode), nullptr); }
 
     bool isDeletingGroup() { return SpeakerSetupLine::isDeletingGroup; }
+    std::unique_ptr<SpeakerSetupLine> mainSpeakerGroupLine;
 
 private:
     GrisLookAndFeel grisLookAndFeel;
@@ -87,13 +89,14 @@ private:
     //header
     juce::Label id, x, y, z, azim, elev, distance, gain, highpass, direct, del, drag;
 
-    juce::TreeView speakerSetupTreeView;
+    SpeakerSetupTreeView speakerSetupTreeView;
     juce::TextButton undoButton{ "Undo" }, redoButton{ "Redo" }, sortButton{ "Sort by ID" };
 
-    std::unique_ptr<SpeakerSetupLine> mainSpeakerGroupLine;
 
     juce::UndoManager& undoManager;
     std::function<void ()> onSelectionChanged;
+
+    std::unique_ptr<juce::XmlElement> opennessState;
 
     void timerCallback() override;
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "SpeakerTreeComponent.hpp"
+#include "SpeakerSetupTreeView.hpp"
 
 namespace gris
 {
@@ -39,9 +40,10 @@ class SpeakerSetupLine final
     , private juce::ValueTree::Listener
 {
 public:
-    SpeakerSetupLine(const juce::ValueTree & v, juce::UndoManager & um, std::function<void()> selectionChanged);
+    SpeakerSetupLine(const juce::ValueTree & v, juce::UndoManager & um, std::function<void()> selectionChanged, SpeakerSetupTreeView & parent);
 
-    juce::String getUniqueName() const override { return lineValueTree.getType().toString(); }
+    SpeakerSetupLine(const juce::ValueTree & v, juce::UndoManager & um, std::function<void()> selectionChanged, SpeakerSetupTreeView & parent, std::unique_ptr<juce::XmlElement> && opennessState);
+    juce::String getUniqueName() const override;
 
     bool isSpeakerGroup() const { return lineValueTree.getType () == SPEAKER_GROUP; }
 
@@ -87,14 +89,21 @@ public:
     tl::optional<output_patch_t> getOutputPatch();
 
     static bool isDeletingGroup;
+    /**
+     * Get a string identifier from a value tree. This will return the output_patch_t for speakers
+     * and the group name for a group. As a result of this, group names now need to be unique
+     */
+    static juce::String getStringFromValueTree(const juce::ValueTree& valueTree);
+
+    std::unique_ptr<juce::XmlElement> opennessState;
+    void resetScroll();
 
 private:
     juce::ValueTree lineValueTree;
     juce::UndoManager& undoManager;
     std::function<void ()> onSelectionChanged;
-
+    SpeakerSetupTreeView & parent;
     void refreshSubItems ();
-
     void itemSelectionChanged(bool isNowSelected) override;
 
     void valueTreeChildAdded (juce::ValueTree& parentTree, juce::ValueTree&) override { treeChildrenChanged (parentTree); }

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupTreeView.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupTreeView.cpp
@@ -1,0 +1,85 @@
+/*
+ This file is part of SpatGRIS.
+
+ SpatGRIS is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SpatGRIS is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SpatGRIS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "SpeakerSetupTreeView.hpp"
+
+namespace gris
+{
+
+SpeakerSetupTreeView::SpeakerSetupTreeView(const juce::String &componentName)
+        :juce::TreeView(componentName) {
+}
+
+void SpeakerSetupTreeView::requestScrollReset(double scrollPosition) {
+    requestedScrollPosition = scrollPosition;
+    scrollResetRequested = true;
+    tries = 0;
+}
+
+void SpeakerSetupTreeView::resetScrollRequest() {
+    requestedScrollPosition = 0.0;
+    scrollResetRequested = false;
+    tries = 0;
+}
+
+void SpeakerSetupTreeView::paint (juce::Graphics & g){
+    juce::TreeView::paint(g);
+    if (!scrollResetRequested) {
+        return;
+    }
+    // if someone requested a scroll position, we try our hardest to comply.
+
+    // if our requested scroll position is 0.0, we are certainly already there since
+    // its the default scroll position we have when our items are reseted. We can safely assume
+    // everything is ok, clear the flag and return.
+    if (requestedScrollPosition == 0.0) {
+        resetScrollRequest();
+        return;
+    }
+    const auto currentScrollPosition = getViewport()->getVerticalScrollBar().getCurrentRangeStart();
+
+    const auto maxRangeLimit = getViewport()->getVerticalScrollBar().getMaximumRangeLimit();
+
+    const auto currentRangeSize = getViewport()->getVerticalScrollBar().getCurrentRangeSize();
+
+    // This is the maximum scroll position we can get according to juce source code. (and docs I think)
+    const auto maxScrollValue = maxRangeLimit - currentRangeSize;
+
+    auto possibleScrollValue = requestedScrollPosition;
+    if (maxScrollValue < possibleScrollValue) {
+        possibleScrollValue = maxScrollValue;
+    }
+
+    // try to set the range here.
+    getViewport()->getVerticalScrollBar().setCurrentRangeStart(possibleScrollValue);
+
+    const auto newScrollPos = getViewport()->getVerticalScrollBar().getCurrentRangeStart();
+
+    // if the position moved, we did our best, consider the request honoured.
+    if (newScrollPos != currentScrollPosition) {
+        resetScrollRequest();
+        return;
+    }
+    // I think there's a possible world where we try to set stuff, we are not at 0,
+    // and the position doesn't change. if this happens a bung of times, just give up.
+    // Note: I have not seen this happen.
+    tries +=1;
+    if (tries > 10) {
+        resetScrollRequest();
+    }
+}
+}

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupTreeView.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupTreeView.hpp
@@ -1,0 +1,61 @@
+/*
+ This file is part of SpatGRIS.
+
+ SpatGRIS is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ SpatGRIS is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with SpatGRIS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "JuceHeader.h"
+
+
+namespace gris
+{
+
+class SpeakerSetupTreeView final
+        : public juce::TreeView
+{
+  public:
+    SpeakerSetupTreeView(const juce::String &componentName={});
+
+    /**
+     * This requests the component to set its viewport's scrollbar to a certain position
+     * at the end of its paint method. I did this because I was running into timing issues
+     * where the resetOpennessState method tried to reset the scrollbar before the viewport
+     * was actually scrollable.
+     */
+    void requestScrollReset(double scrollPosition);
+    /**
+     * This generally just calls the treeview's paint but if requestScrollReset was called
+     * it will also try to move the scrollbar.
+     *
+     * It will try 10 (or 11 ?) times to change the position to the requested position. It
+     * will consider the request honoured if the scrollbar moved in anyway, if the requested position is 0.0 or if it tries too many times.
+     */
+    void paint (juce::Graphics & g);
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SpeakerSetupTreeView)
+
+  private:
+    bool scrollResetRequested = false;
+    double requestedScrollPosition = 0.0;
+    unsigned int tries = 0;
+
+    /**
+     * sets all the scroll reset properties to their defalt values.
+     */
+    void resetScrollRequest();
+};
+
+}

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -539,6 +539,7 @@ void EditSpeakersWindow::togglePolyhedraExtraWidgets()
     mPolyRadius.setVisible(showExtendedPolyWidgets);
 }
 
+
 //==============================================================================
 void EditSpeakersWindow::updateWinContent()
 {
@@ -552,6 +553,7 @@ void EditSpeakersWindow::updateWinContent()
                                 || spatGrisData.project.spatMode == SpatMode::hybrid);
 
     togglePolyhedraExtraWidgets();
+    mSpeakerSetupContainer.mainSpeakerGroupLine->resetScroll();
 }
 
 //==============================================================================
@@ -808,6 +810,7 @@ void EditSpeakersWindow::valueTreeChildAdded(juce::ValueTree & parent, juce::Val
 
 void EditSpeakersWindow::valueTreeChildRemoved(juce::ValueTree & /*parent*/, juce::ValueTree & child, [[maybe_unused]] int index)
 {
+
     auto const childType { child.getType () };
 
 #if DEBUG_SPEAKER_EDITION

--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -161,6 +161,10 @@
                   file="Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.cpp"/>
             <FILE id="nAM1Vt" name="SpeakerSetupLine.hpp" compile="0" resource="0"
                   file="Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp"/>
+            <FILE id="tvs7BE" name="SpeakerSetupTreeView.cpp" compile="1" resource="0"
+                  file="Source/UI/Windows/SpeakerSetup/SpeakerSetupTreeView.cpp"/>
+            <FILE id="nleBbR" name="SpeakerSetupTreeView.hpp" compile="0" resource="0"
+                  file="Source/UI/Windows/SpeakerSetup/SpeakerSetupTreeView.hpp"/>
             <FILE id="Bsj2dV" name="SpeakerTreeComponent.cpp" compile="1" resource="0"
                   file="Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp"/>
             <FILE id="xOpYoh" name="SpeakerTreeComponent.hpp" compile="0" resource="0"


### PR DESCRIPTION
With the addition of speaker groups and the TreeView, there were some small UX regressions in the speaker setup window.

This fixes two of them:
- The window now tries to go back to the same scroll position after an operation
- The groups will keep their old openness after an operation instead of reseting to open.


There is a last regression which I'm aware of which is that the spat algorithm is reset when moving speakers around. This PR does not fix it.

Fixes https://github.com/GRIS-UdeM/SpatGRIS/issues/502