### PR TITLE
Add rtsan support

### DIFF
--- a/Source/sg_AudioProcessor.cpp
+++ b/Source/sg_AudioProcessor.cpp
@@ -113,7 +113,7 @@ void AudioProcessor::processAudio(SourceAudioBuffer & sourceBuffer,
                                   ForkUnionBuffer & forkUnionBuffer,
     #endif
 #endif
-                                  juce::AudioBuffer<float> & stereoBuffer) noexcept
+                                  juce::AudioBuffer<float> & stereoBuffer) noexcept [[clang::nonblocking]]
 {
     // Skip if the user is editing the speaker setup.
     juce::ScopedTryLock const lock{ mLock };

--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -400,6 +400,8 @@
                        recommendedWarnings="GCC" extraCompilerFlags="-fdiagnostics-color=always"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="SpatGRIS"
                        linkTimeOptimisation="1" recommendedWarnings="GCC"/>
+        <CONFIGURATION isDebug="0" name="RTSan" extraCompilerFlags="-fdiagnostics-color=always -fsanitize=realtime -v"
+                       optimisation="1" recommendedWarnings="GCC" extraLinkerFlags="-fsanitize=realtime"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_osc" path="submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/modules"/>

--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -400,7 +400,7 @@
                        recommendedWarnings="GCC" extraCompilerFlags="-fdiagnostics-color=always"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="SpatGRIS"
                        linkTimeOptimisation="1" recommendedWarnings="GCC"/>
-        <CONFIGURATION isDebug="0" name="RTSan" extraCompilerFlags="-fdiagnostics-color=always -fsanitize=realtime -v"
+        <CONFIGURATION isDebug="0" name="RTSan" extraCompilerFlags="-fdiagnostics-color=always -fsanitize=realtime"
                        optimisation="1" recommendedWarnings="GCC" extraLinkerFlags="-fsanitize=realtime"/>
       </CONFIGURATIONS>
       <MODULEPATHS>


### PR DESCRIPTION
This support to build a version of SpatGRIS with `fsanitize=realtime` with clang >= 20.