### PR TITLE
Reintroduce sortable columns in the speaker setup window

### DIFF
--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
@@ -44,7 +44,6 @@ SpeakerSetupContainer::SpeakerSetupContainer(const juce::File & speakerSetupXmlF
 
     addAndMakeVisible (undoButton);
     addAndMakeVisible (redoButton);
-    addAndMakeVisible (sortButton);
 
     addAndMakeVisible(containerHeader);
     containerHeader.setSortFunc([this](SpeakerColumnHeader::ColumnID sortID, int sortDirection) { mainSpeakerGroupLine->sort ({}, sortID, sortDirection); });
@@ -98,7 +97,6 @@ void SpeakerSetupContainer::resized()
     buttons.removeFromLeft(6);
     redoButton.setBounds(buttons.removeFromLeft(100));
     buttons.removeFromLeft(6);
-    sortButton.setBounds(buttons.removeFromLeft(100));
 
     bounds.removeFromBottom(4);
     speakerSetupTreeView.setBounds(bounds);

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
@@ -64,7 +64,7 @@ SpeakerSetupContainer::SpeakerSetupContainer(const juce::File & speakerSetupXmlF
 
     undoButton.onClick = [this] { undoManager.undo (); };
     redoButton.onClick = [this] { undoManager.redo (); };
-    sortButton.onClick = [this] { mainSpeakerGroupLine->sort (); };
+    sortButton.onClick = [this] { mainSpeakerGroupLine->sort ({}, SPEAKER_PATCH_ID); };
 
     startTimer (500);
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
@@ -88,7 +88,7 @@ private:
     SpeakerSetupContainerHeader containerHeader;
     juce::TreeView speakerSetupTreeView;
 
-    juce::TextButton undoButton{ "Undo" }, redoButton{ "Redo" }, sortButton{ "Sort by ID" };
+    juce::TextButton undoButton{ "Undo" }, redoButton{ "Redo" };
 
     std::unique_ptr<SpeakerSetupLine> mainSpeakerGroupLine;
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
@@ -23,6 +23,38 @@
 
 namespace gris
 {
+
+class ColumnHeader final
+    : public juce::Label
+{
+  public:
+    /**
+     * paints little sort arrows in the right places.
+     */
+    void paint(juce::Graphics& g) override;
+
+    int width;
+
+    // void mouseUp (const MouseEvent& e) override;
+
+  private:
+    bool isSorting{false};
+    bool sortDirection{1};
+};
+
+class SpeakerSetupContainerHeader final
+    : public juce::Component
+{
+  public:
+    SpeakerSetupContainerHeader(GrisLookAndFeel& grisLookAndFeel);
+
+    void resized() override;
+
+  private:
+    ColumnHeader id, x, y, z, azim, elev, distance, gain, highpass, direct, del, drag;
+    GrisLookAndFeel& grisLookAndFeel;
+};
+
 /**
  * @class gris::SpeakerSetupContainer
  * @brief A UI component for managing and displaying speaker setups in a tree view.
@@ -84,10 +116,7 @@ private:
     GrisLookAndFeel grisLookAndFeel;
     juce::String speakerSetupFileName;
     juce::ValueTree speakerSetupVt;
-
-    //header
-    juce::Label id, x, y, z, azim, elev, distance, gain, highpass, direct, del, drag;
-
+    SpeakerSetupContainerHeader containerHeader;
     juce::TreeView speakerSetupTreeView;
 
     juce::TextButton undoButton{ "Undo" }, redoButton{ "Redo" }, sortButton{ "Sort by ID" };

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
@@ -24,37 +24,6 @@
 namespace gris
 {
 
-class ColumnHeader final
-    : public juce::Label
-{
-  public:
-    /**
-     * paints little sort arrows in the right places.
-     */
-    void paint(juce::Graphics& g) override;
-
-    int width;
-
-    // void mouseUp (const MouseEvent& e) override;
-
-  private:
-    bool isSorting{false};
-    bool sortDirection{1};
-};
-
-class SpeakerSetupContainerHeader final
-    : public juce::Component
-{
-  public:
-    SpeakerSetupContainerHeader(GrisLookAndFeel& grisLookAndFeel);
-
-    void resized() override;
-
-  private:
-    ColumnHeader id, x, y, z, azim, elev, distance, gain, highpass, direct, del, drag;
-    GrisLookAndFeel& grisLookAndFeel;
-};
-
 /**
  * @class gris::SpeakerSetupContainer
  * @brief A UI component for managing and displaying speaker setups in a tree view.

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.cpp
@@ -74,8 +74,6 @@ SpeakerSetupContainerHeader::SpeakerSetupContainerHeader(GrisLookAndFeel& glaf)
                 return;
             }
             int sortDirection = sortState == SpeakerColumnHeader::SortState::ascending ? 1 : -1;
-            std::cout << sortDirection << "\n";
-
             sortFunc(sortID, sortDirection);
             disableOtherHeaders(clickedHeader);
         };
@@ -95,16 +93,18 @@ SpeakerSetupContainerHeader::SpeakerSetupContainerHeader(GrisLookAndFeel& glaf)
     setHeaderText (highpass, "Highpass");
     setHeaderText (direct, "Direct");
     setHeaderText (del, "Delete");
-    constexpr std::array<SpeakerColumnHeader::ColumnID, 6> headerKeys = {
+    constexpr std::array<SpeakerColumnHeader::ColumnID, 8> headerKeys = {
         SpeakerColumnHeader::ColumnID::X,
         SpeakerColumnHeader::ColumnID::Y,
         SpeakerColumnHeader::ColumnID::Z,
         SpeakerColumnHeader::ColumnID::Azimuth,
         SpeakerColumnHeader::ColumnID::Elevation,
-        SpeakerColumnHeader::ColumnID::Distance
+        SpeakerColumnHeader::ColumnID::Distance,
+        SpeakerColumnHeader::ColumnID::Gain,
+        SpeakerColumnHeader::ColumnID::Highpass,
     };
     size_t i = 0;
-    for (const auto header : { &x, &y, &z, &azim, &elev, &distance}) {
+    for (const auto header : { &x, &y, &z, &azim, &elev, &distance, &gain, &highpass}) {
         header->width = SpeakerTreeComponent::otherColWidth;
         header->arrowColor = grisLookAndFeel.mOnColor;
         header->setSortCallback(makeSortFunction(headerKeys[i]));
@@ -117,11 +117,11 @@ void SpeakerSetupContainerHeader::resized() {
     auto height = getLocalBounds().getHeight();
     id.setBounds(0, 0, id.width, height);
     auto currentX = id.width;
-    for (const auto header : { &x, &y, &z, &azim, &elev, &distance }) {
+    for (const auto header : { &x, &y, &z, &azim, &elev, &distance, &gain, &highpass }) {
         header->setBounds(currentX, 0, header->width, height);
         currentX += header->width;
     }
-    for (const auto label : { &gain, &highpass, &direct, &del }) {
+    for (const auto label : { &direct, &del }) {
         label->setBounds(currentX, 0, SpeakerTreeComponent::otherColWidth, height);
         currentX += SpeakerTreeComponent::otherColWidth;
     }

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.cpp
@@ -1,0 +1,135 @@
+#include "SpeakerSetupContainerHeader.hpp"
+#include "SpeakerTreeComponent.hpp"
+#include <array>
+
+namespace gris
+{
+
+void SpeakerColumnHeader::paint(juce::Graphics& g) {
+    // start by painting the label
+    juce::Label::paint(g);
+    if (sortState == SortState::none) {
+        return;
+    }
+    // paints the little arrow thingy if necessary.
+    g.setColour (arrowColor);
+    juce::Path sortTriangle;
+    const auto middle = getLocalBounds().getHeight()/2;
+    constexpr auto triangleRightPad = 4;
+    constexpr auto triangleWidth = 10;
+    constexpr auto triangleHeight = 4;
+    if (sortState == SortState::ascending)
+        sortTriangle.addTriangle (width - triangleRightPad - triangleWidth, middle + triangleHeight, width - triangleRightPad, middle + triangleHeight, width - triangleRightPad - (triangleWidth/2), middle - triangleHeight);
+    else
+        sortTriangle.addTriangle (width - triangleRightPad - triangleWidth, middle - triangleHeight, width - triangleRightPad, middle - triangleHeight, width - triangleRightPad - (triangleWidth/2), middle + triangleHeight);
+    g.fillPath (sortTriangle);
+}
+
+void SpeakerColumnHeader::mouseUp (const juce::MouseEvent& e) {
+    // Basically state transition (and repaint) + sort callback for the parent.
+    switch (sortState) {
+        case SortState::none:
+            setState(SortState::ascending);
+            break;
+        case SortState::ascending:
+            setState(SortState::descending);
+            break;
+        case SortState::descending:
+            setState(SortState::ascending);
+            break;
+    }
+    sortCallback(this, sortState);
+}
+
+void SpeakerColumnHeader::setState(const SortState newState) {
+    sortState = newState;
+    // repaint to show the changed sort arrow
+    repaint();
+}
+
+void SpeakerColumnHeader::setSortCallback(std::function<void(const SpeakerColumnHeader*, const SortState)> callback) {
+    sortCallback = callback;
+}
+
+SpeakerSetupContainerHeader::SpeakerSetupContainerHeader(GrisLookAndFeel& glaf)
+
+    : grisLookAndFeel(glaf)
+{
+    auto setHeaderText = [this](juce::Label& label, const juce::String & text) {
+        label.setColour (juce::Label::ColourIds::outlineColourId, grisLookAndFeel.mLightColour.withAlpha (.25f));
+        label.setText(text, juce::dontSendNotification);
+        addAndMakeVisible(label);
+    };
+
+    auto disableOtherHeaders = [this](const SpeakerColumnHeader* clickedHeader) {
+        for (const auto header : {&id, &x, &y, &z, &azim, &elev, &distance}) {
+            if (clickedHeader != header) {
+                header->setState(SpeakerColumnHeader::SortState::none);
+            }
+        }
+    };
+    auto makeSortFunction = [this, disableOtherHeaders](SpeakerColumnHeader::ColumnID sortID) {
+        return [this, sortID, disableOtherHeaders](const SpeakerColumnHeader* clickedHeader, const SpeakerColumnHeader::SortState sortState) {
+            if (sortState == SpeakerColumnHeader::SortState::none) {
+                return;
+            }
+            int sortDirection = sortState == SpeakerColumnHeader::SortState::ascending ? 1 : -1;
+            std::cout << sortDirection << "\n";
+
+            sortFunc(sortID, sortDirection);
+            disableOtherHeaders(clickedHeader);
+        };
+    };
+    setHeaderText (id, "ID");
+    constexpr auto realIdWidth = SpeakerTreeComponent::fixedLeftColWidth-28;
+    id.width = realIdWidth;
+    id.arrowColor = grisLookAndFeel.mOnColor;
+    id.setSortCallback(makeSortFunction(SpeakerColumnHeader::ColumnID::ID));
+    setHeaderText (x, "X");
+    setHeaderText (y, "Y");
+    setHeaderText (z, "Z");
+    setHeaderText (azim, "Azimuth");
+    setHeaderText (elev, "Elevation");
+    setHeaderText (distance, "Distance");
+    setHeaderText (gain, "Gain");
+    setHeaderText (highpass, "Highpass");
+    setHeaderText (direct, "Direct");
+    setHeaderText (del, "Delete");
+    constexpr std::array<SpeakerColumnHeader::ColumnID, 6> headerKeys = {
+        SpeakerColumnHeader::ColumnID::X,
+        SpeakerColumnHeader::ColumnID::Y,
+        SpeakerColumnHeader::ColumnID::Z,
+        SpeakerColumnHeader::ColumnID::Azimuth,
+        SpeakerColumnHeader::ColumnID::Elevation,
+        SpeakerColumnHeader::ColumnID::Distance
+    };
+    size_t i = 0;
+    for (const auto header : { &x, &y, &z, &azim, &elev, &distance}) {
+        header->width = SpeakerTreeComponent::otherColWidth;
+        header->arrowColor = grisLookAndFeel.mOnColor;
+        header->setSortCallback(makeSortFunction(headerKeys[i]));
+        i++;
+    }
+    setHeaderText (drag, "Drag");
+}
+
+void SpeakerSetupContainerHeader::resized() {
+    auto height = getLocalBounds().getHeight();
+    id.setBounds(0, 0, id.width, height);
+    auto currentX = id.width;
+    for (const auto header : { &x, &y, &z, &azim, &elev, &distance }) {
+        header->setBounds(currentX, 0, header->width, height);
+        currentX += header->width;
+    }
+    for (const auto label : { &gain, &highpass, &direct, &del }) {
+        label->setBounds(currentX, 0, SpeakerTreeComponent::otherColWidth, height);
+        currentX += SpeakerTreeComponent::otherColWidth;
+    }
+    constexpr auto dragColWidth{ 40 };
+    drag.setBounds(currentX, 0, dragColWidth, height);
+}
+
+void SpeakerSetupContainerHeader::setSortFunc(std::function<void(SpeakerColumnHeader::ColumnID, int sortDirection)> sort) {
+    sortFunc = sort;
+}
+}

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "../../../sg_GrisLookAndFeel.hpp"
+
+namespace gris
+{
+
+class SpeakerColumnHeader final
+    : public juce::Label
+{
+  public:
+
+    /**
+     * paints little sort arrows in the right places.
+     */
+    void paint(juce::Graphics& g) override;
+
+    int width;
+
+
+    void mouseUp (const juce::MouseEvent& e) override;
+    juce::Colour arrowColor;
+    /**
+     * none sort state means no arrows are painted.
+     *
+     * the state transitions are
+     *
+     * none -> ascending <-> descending.
+     *
+     * none can only be reached at initialization and by a call to setState.
+     */
+    enum class SortState { none, ascending, descending }; // enum class
+
+    enum class ColumnID { ID, X, Y, Z, Azimuth, Elevation, Distance };
+
+    void setState(SortState newState);
+
+    void setSortCallback(std::function<void(const SpeakerColumnHeader*, const SortState)>);
+
+  private:
+    SortState sortState { SortState::none };
+    /**
+     * Sorting callback that is called with the column's state when it is clicked.
+     */
+    std::function<void(const SpeakerColumnHeader*, const SortState)> sortCallback;
+};
+
+class SpeakerSetupContainerHeader final
+    : public juce::Component
+{
+  public:
+    SpeakerSetupContainerHeader(GrisLookAndFeel& grisLookAndFeel);
+
+    void resized() override;
+    void setSortFunc(std::function<void(SpeakerColumnHeader::ColumnID, int)>);
+  private:
+    SpeakerColumnHeader id, x, y, z, azim, elev, distance;
+    juce::Label gain, highpass, direct, del, drag;
+    GrisLookAndFeel& grisLookAndFeel;
+    std::function<void(SpeakerColumnHeader::ColumnID, int)> sortFunc;
+};
+}

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.hpp
@@ -32,7 +32,7 @@ class SpeakerColumnHeader final
      */
     enum class SortState { none, ascending, descending }; // enum class
 
-    enum class ColumnID { ID, X, Y, Z, Azimuth, Elevation, Distance };
+    enum class ColumnID { ID, X, Y, Z, Azimuth, Elevation, Distance, Gain, Highpass };
 
     void setState(SortState newState);
 
@@ -55,8 +55,8 @@ class SpeakerSetupContainerHeader final
     void resized() override;
     void setSortFunc(std::function<void(SpeakerColumnHeader::ColumnID, int)>);
   private:
-    SpeakerColumnHeader id, x, y, z, azim, elev, distance;
-    juce::Label gain, highpass, direct, del, drag;
+    SpeakerColumnHeader id, x, y, z, azim, elev, distance, gain, highpass;
+    juce::Label direct, del, drag;
     GrisLookAndFeel& grisLookAndFeel;
     std::function<void(SpeakerColumnHeader::ColumnID, int)> sortFunc;
 };

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.cpp
@@ -151,6 +151,12 @@ void SpeakerSetupLine::selectChildSpeaker(tl::optional<output_patch_t> const out
               case SpeakerColumnHeader::ColumnID::Distance:
                   sortValue = position.getPolar().length;
                   break;
+              case SpeakerColumnHeader::ColumnID::Gain:
+                  sortValue = valueTree[GAIN];
+                  break;
+              case SpeakerColumnHeader::ColumnID::Highpass:
+                  sortValue = valueTree[HIGHPASS_FREQ];
+                  break;
           }
           return sortValue;
       }

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
@@ -80,7 +80,7 @@ public:
 
     void selectChildSpeaker (tl::optional<output_patch_t> const outputPatch);
 
-    void sort (juce::ValueTree vt = {});
+    void sort (juce::ValueTree vt, juce::Identifier comparisonKey);
 
     juce::ValueTree getValueTree() { return lineValueTree; }
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "SpeakerTreeComponent.hpp"
+#include "SpeakerSetupContainerHeader.hpp"
 
 namespace gris
 {
@@ -80,7 +81,7 @@ public:
 
     void selectChildSpeaker (tl::optional<output_patch_t> const outputPatch);
 
-    void sort (juce::ValueTree vt, juce::Identifier comparisonKey);
+    void sort (juce::ValueTree vt, SpeakerColumnHeader::ColumnID comparisonKey, int sortDirection);
 
     juce::ValueTree getValueTree() { return lineValueTree; }
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
@@ -481,14 +481,17 @@ void SpeakerComponent::editorShown (juce::Label* label, juce::TextEditor& editor
 
 void SpeakerComponent::setupGain ()
 {
-    gain.setEditable (true);
-    gain.setText (speakerTreeVt[GAIN], juce::dontSendNotification);
 
     const auto getClampedGain = [](float gainValue) {
         static constexpr dbfs_t MIN_GAIN { -18.0f };
         static constexpr dbfs_t MAX_GAIN { 6.0f };
         return std::clamp (dbfs_t (gainValue), MIN_GAIN, MAX_GAIN);
         };
+
+    gain.setEditable (true);
+    // clamp the gain on first display.
+    auto clampedGainText = juce::String(getClampedGain(static_cast<float>(speakerTreeVt[GAIN])).get(), 1);
+    gain.setText (clampedGainText, juce::dontSendNotification);
 
     gain.onTextChange = [this, getClampedGain] {
         auto const clampedValue = getClampedGain (gain.getText ().getFloatValue ()).get ();

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.hpp
@@ -76,7 +76,7 @@ class SpeakerTreeComponent
 {
 public:
     static constexpr auto fixedLeftColWidth { 200 };
-    static constexpr auto otherColWidth { 60 };
+    static constexpr auto otherColWidth { 70 };
     static constexpr auto colGap { 15 };
 
     juce::ValueTree speakerTreeVt;

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -207,7 +207,7 @@ EditSpeakersWindow::EditSpeakersWindow(juce::String const & name,
     setContentNonOwned(&mViewportWrapper, false);
     auto const & controlsComponent{ *mainContentComponent.getControlsComponent() };
 
-    static constexpr auto WIDTH = 850;
+    static constexpr auto WIDTH = 950;
     static constexpr auto HEIGHT = 600;
     static constexpr auto TITLE_BAR_HEIGHT = 30;
 

--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -157,6 +157,10 @@
                   file="Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp"/>
             <FILE id="YE6iq2" name="SpeakerSetupContainer.hpp" compile="0" resource="0"
                   file="Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp"/>
+            <FILE id="CJK9qF" name="SpeakerSetupContainerHeader.cpp" compile="1"
+                  resource="0" file="Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.cpp"/>
+            <FILE id="fSIssW" name="SpeakerSetupContainerHeader.hpp" compile="0"
+                  resource="0" file="Source/UI/Windows/SpeakerSetup/SpeakerSetupContainerHeader.hpp"/>
             <FILE id="ZaUlNe" name="SpeakerSetupLine.cpp" compile="1" resource="0"
                   file="Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.cpp"/>
             <FILE id="nAM1Vt" name="SpeakerSetupLine.hpp" compile="0" resource="0"


### PR DESCRIPTION
The sort function for the table was lost in the rewrite with TreeViews. This reintroduces the feature.