### PR TITLE
Fix invalid highpass values being saved in the speaker setup when manually setting a highpass to 0.

### DIFF
--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
@@ -543,15 +543,23 @@ void SpeakerComponent::setupHighPass()
 
         return std::clamp(hz_t(freqValue), MIN_FREQ, MAX_FREQ);
     };
+    // If the value is < 20.0, it is an invalid highpass value and it should not be saved in the tree.
+    const auto setHighpassInTree = [this](float value) {
+        if (value >= 20.0) {
+            speakerTreeVt.setProperty(HIGHPASS_FREQ, value, &undoManager);
+        } else {
+            speakerTreeVt.removeProperty(HIGHPASS_FREQ, &undoManager);
+        }
+    };
 
-    highpass.onTextChange = [this, getClampedFrequency] {
+    highpass.onTextChange = [this, getClampedFrequency, setHighpassInTree] {
         auto const clampedValue = getClampedFrequency(highpass.getText().getFloatValue()).get();
 
         highpass.setText(juce::String(clampedValue, 1), juce::dontSendNotification);
-        speakerTreeVt.setProperty(HIGHPASS_FREQ, clampedValue, &undoManager);
+        setHighpassInTree(clampedValue);
     };
 
-    highpass.onMouseDragCallback = [this, getClampedFrequency](int deltaY) {
+    highpass.onMouseDragCallback = [this, getClampedFrequency, setHighpassInTree](int deltaY) {
         if (! highpass.isEnabled ())
             return;
 
@@ -559,7 +567,7 @@ void SpeakerComponent::setupHighPass()
         auto const clampedValue{ getClampedFrequency(draggedValue, deltaY < 0).get() };
 
         highpass.setText(juce::String(clampedValue, 1), juce::dontSendNotification);
-        speakerTreeVt.setProperty(HIGHPASS_FREQ, clampedValue, &undoManager);
+        setHighpassInTree(clampedValue);
     };
 
     addAndMakeVisible(highpass);


### PR DESCRIPTION
This fixes https://github.com/GRIS-UdeM/SpatGRIS/issues/527