### PR TITLE
Fix speaker ordering ignoring the speaker setup window's order for speaker groups

### DIFF
--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
@@ -137,6 +137,10 @@ bool SpeakerSetupContainer::keyPressed (const juce::KeyPress& key)
     return Component::keyPressed (key);
 }
 
+const juce::ValueTree& SpeakerSetupContainer::getSpeakerSetupVt() {
+    return speakerSetupVt;
+}
+
 juce::ValueTree SpeakerSetupContainer::getSelectedItem()
 {
     //if we have a selection, return the last selected item. Otherwise return the last overall item

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.hpp
@@ -81,6 +81,8 @@ public:
 
     bool isDeletingGroup() { return SpeakerSetupLine::isDeletingGroup; }
 
+    const juce::ValueTree& getSpeakerSetupVt();
+
 private:
     GrisLookAndFeel grisLookAndFeel;
     juce::String speakerSetupFileName;

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -699,15 +699,13 @@ output_patch_t EditSpeakersWindow::getSpeakerOutputPatchForRow(int const row) co
 
 juce::Array<output_patch_t> EditSpeakersWindow::getSpeakerOutputPatchOrder()
 {
-
     juce::Array<output_patch_t> order;
 
-    std::function<void(const juce::ValueTree& valueTree)> appendToOrder;
     // this function recursively appends the number to a list.
-    appendToOrder = [&appendToOrder, &order](const juce::ValueTree& valueTree) {
+    const auto appendToOrder = [&order](this const auto & self, const juce::ValueTree & valueTree) -> void {
         if (valueTree.getType() == SPEAKER_GROUP || valueTree.getType() == SPEAKER_SETUP) {
-            for (auto child: valueTree) {
-                appendToOrder(child);
+            for (auto child : valueTree) {
+                self(child);
             }
         } else {
             order.add(output_patch_t{ valueTree.getProperty(SPEAKER_PATCH_ID) });

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -361,7 +361,12 @@ void EditSpeakersWindow::buttonClicked(juce::Button * button)
         //for now all rings are centered at the origin
         auto const groupPosition = Position { { 0.f, 0.f, 0.f } };
 
+        isAddingGroup = true;
         addSpeakerGroup(mRingSpeakers.getTextAs<int>(), groupPosition, getSpeakerPosition);
+        isAddingGroup = false;
+        // When every speaker is added, recompute the order.
+        mMainContentComponent.reorderSpeakers(getSpeakerOutputPatchOrder());
+        mMainContentComponent.requestSpeakerRefresh();
     } else if (button == &mAddPolyButton) {
 
         auto const numFaces { mPolyFaces.getSelectionAsInt () };
@@ -443,6 +448,9 @@ void EditSpeakersWindow::buttonClicked(juce::Button * button)
         isAddingGroup = true;
         addSpeakerGroup(numFaces, groupPosition, getSpeakerPosition);
         isAddingGroup = false;
+        // when everything is added, recompute the order and request a refresh.
+        mMainContentComponent.reorderSpeakers(getSpeakerOutputPatchOrder());
+        mMainContentComponent.requestSpeakerRefresh();
     } else if (button == &mPinkNoiseToggleButton) {
         // Pink noise button
         tl::optional<dbfs_t> newPinkNoiseLevel{};
@@ -820,6 +828,9 @@ void EditSpeakersWindow::valueTreeChildAdded(juce::ValueTree & parent, juce::Val
             indexAdjustment = mainGroup.indexOf(parent);
         }
         mMainContentComponent.addSpeaker(*SpeakerData::fromVt(child), index + indexAdjustment, childOutputPatch);
+    } else {
+        // when we are adding a group, just recompute the order from scratch.
+        mMainContentComponent.reorderSpeakers(getSpeakerOutputPatchOrder());
     }
 
     if (!isAddingGroup) {

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -704,7 +704,7 @@ juce::Array<output_patch_t> EditSpeakersWindow::getSpeakerOutputPatchOrder()
 
     std::function<void(const juce::ValueTree& valueTree)> appendToOrder;
     // this function recursively appends the number to a list.
-    appendToOrder = [&](const juce::ValueTree& valueTree) {
+    appendToOrder = [&appendToOrder, &order](const juce::ValueTree& valueTree) {
         if (valueTree.getType() == SPEAKER_GROUP || valueTree.getType() == SPEAKER_SETUP) {
             for (auto child: valueTree) {
                 appendToOrder(child);

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -689,6 +689,27 @@ output_patch_t EditSpeakersWindow::getSpeakerOutputPatchForRow(int const row) co
     return result;
 }
 
+juce::Array<output_patch_t> EditSpeakersWindow::getSpeakerOutputPatchOrder()
+{
+
+    juce::Array<output_patch_t> order;
+
+    std::function<void(const juce::ValueTree& valueTree)> appendToOrder;
+    // this function recursively appends the number to a list.
+    appendToOrder = [&](const juce::ValueTree& valueTree) {
+        if (valueTree.getType() == SPEAKER_GROUP || valueTree.getType() == SPEAKER_SETUP) {
+            for (auto child: valueTree) {
+                appendToOrder(child);
+            }
+        } else {
+            order.add(output_patch_t{ valueTree.getProperty(SPEAKER_PATCH_ID) });
+        }
+    };
+    const auto vt = mSpeakerSetupContainer.getSpeakerSetupVt();
+    appendToOrder(vt);
+    return order;
+}
+
 //==============================================================================
 void EditSpeakersWindow::computeSpeakers()
 {

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -699,13 +699,15 @@ output_patch_t EditSpeakersWindow::getSpeakerOutputPatchForRow(int const row) co
 
 juce::Array<output_patch_t> EditSpeakersWindow::getSpeakerOutputPatchOrder()
 {
+
     juce::Array<output_patch_t> order;
 
+    std::function<void(const juce::ValueTree& valueTree)> appendToOrder;
     // this function recursively appends the number to a list.
-    const auto appendToOrder = [&order](this const auto & self, const juce::ValueTree & valueTree) -> void {
+    appendToOrder = [&appendToOrder, &order](const juce::ValueTree& valueTree) {
         if (valueTree.getType() == SPEAKER_GROUP || valueTree.getType() == SPEAKER_SETUP) {
-            for (auto child : valueTree) {
-                self(child);
+            for (auto child: valueTree) {
+                appendToOrder(child);
             }
         } else {
             order.add(output_patch_t{ valueTree.getProperty(SPEAKER_PATCH_ID) });

--- a/Source/sg_EditSpeakersWindow.hpp
+++ b/Source/sg_EditSpeakersWindow.hpp
@@ -184,6 +184,10 @@ public:
     *   when the spatMode changes.*/
     void updateWinContent();
 
+    /**
+     * Returns the speaker ordering exactly as it is displayed in the window.
+     */
+    juce::Array<output_patch_t> getSpeakerOutputPatchOrder();
 private:
     bool isAddingGroup = false;
     //==============================================================================

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -1731,7 +1731,6 @@ bool MainContentComponent::isSpeakerSetupModified() const
     if (!savedSpeakerSetup) {
         return true;
     }
-    // additionnal
 
     return mData.speakerSetup != *savedSpeakerSetup;
 }

--- a/Source/sg_MainComponent.hpp
+++ b/Source/sg_MainComponent.hpp
@@ -249,7 +249,10 @@ public:
     output_patch_t addSpeaker(tl::optional<output_patch_t> speakerToCopy, tl::optional<int> index);
     void addSpeaker(const SpeakerData & speakerData, int index, output_patch_t newOutputPatch);
     void removeSpeaker(output_patch_t outputPatch, bool shouldRefreshSpeakers = true);
-    void reorderSpeakers(juce::Array<output_patch_t> newOrder);
+    /**
+     * Note: This doesn't refresh speaker, call requestSpeakerRefresh() afterwards to see the change.
+     */
+    void reorderSpeakers(juce::Array<output_patch_t>&& newOrder);
     [[nodiscard]] output_patch_t getMaxSpeakerOutputPatch() const;
 
     [[nodiscard]] AudioProcessor & getAudioProcessor() { return *mAudioProcessor; }


### PR DESCRIPTION
Before this, when you moved a speaker group around in the speaker setup window, the vue meter would not honour the order of the speakers in the groups.