### PR TITLE
Add a "use multicore DSP" button that enables parallel processing in VBAP, MPAB and hybrid mode

### DIFF
--- a/.github/workflows/SpatGris-builds.yml
+++ b/.github/workflows/SpatGris-builds.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           sudo apt-get install -y ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev libfreetype6-dev \
               libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev mesa-common-dev libjack-jackd2-dev \
-              libfontconfig1-dev libx11-dev libxext-dev libxrender-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev
+              libfontconfig1-dev libx11-dev libxext-dev libxrender-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev libnuma-dev
       - name: Build Projucer
         run: make -C submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/extras/Projucer/Builds/LinuxMakefile CONFIG=Release -j$(nproc)
 
@@ -106,7 +106,7 @@ jobs:
         run: |
           apt-get install -y ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev libfreetype6-dev \
               libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev mesa-common-dev libjack-jackd2-dev \
-              libfontconfig1-dev libx11-dev libxext-dev libxrender-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev
+              libfontconfig1-dev libx11-dev libxext-dev libxrender-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev libnuma-dev
       - name: Build Projucer
         run: make -C submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/extras/Projucer/Builds/LinuxMakefile CXX=clang++-18 -j$(nproc)
 

--- a/.github/workflows/SpatGris-builds.yml
+++ b/.github/workflows/SpatGris-builds.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get install -y ladspa-sdk freeglut3-dev libasound2-dev libcurl4-openssl-dev libfreetype6-dev \
               libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev mesa-common-dev libjack-jackd2-dev \
-              libfontconfig1-dev libx11-dev libxext-dev libxrender-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev
+              libfontconfig1-dev libx11-dev libxext-dev libxrender-dev libwebkit2gtk-4.1-dev libglu1-mesa-dev libnuma-dev
       - name: Build Projucer
         run: make -C submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/extras/Projucer/Builds/LinuxMakefile CONFIG=Release -j$(nproc)
 

--- a/Source/UI/Windows/SpeakerSetup/SpeakerGroupSettingsWindow.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerGroupSettingsWindow.cpp
@@ -1,4 +1,4 @@
-﻿#include "SpeakerGroupSettingsWindow.hpp"
+#include "SpeakerGroupSettingsWindow.hpp"
 #include "Data/sg_LogicStrucs.hpp"
 
 namespace gris

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  This file is part of SpatGRIS.
 
  SpatGRIS is free software: you can redistribute it and/or modify

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  This file is part of SpatGRIS.
 
  SpatGRIS is free software: you can redistribute it and/or modify

--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupLine.hpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  This file is part of SpatGRIS.
 
  SpatGRIS is free software: you can redistribute it and/or modify

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  This file is part of SpatGRIS.
 
  SpatGRIS is free software: you can redistribute it and/or modify

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.hpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  This file is part of SpatGRIS.
 
  SpatGRIS is free software: you can redistribute it and/or modify

--- a/Source/sg_AudioManager.cpp
+++ b/Source/sg_AudioManager.cpp
@@ -95,10 +95,6 @@ void AudioManager::audioDeviceIOCallbackWithContext (const float* const* inputCh
     // TODO: should not process if stereo mode is hrtf
     mOutputBuffer.silence();
 
-#if SG_USE_FORK_UNION && (SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS || SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD)
-    mAudioProcessor->silenceForkUnionBuffer (forkUnionBuffer);
-#endif
-
     std::for_each_n(outputChannelData, totalNumOutputChannels, [numSamples](float * const data) {
         std::fill_n(data, numSamples, 0.0f);
     });
@@ -140,9 +136,6 @@ void AudioManager::audioDeviceIOCallbackWithContext (const float* const* inputCh
     // do the actual processing
     mAudioProcessor->processAudio(mInputBuffer,
                                   mOutputBuffer,
-#if SG_USE_FORK_UNION && (SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS || SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD)
-                                  forkUnionBuffer,
-#endif
                                   mStereoOutputBuffer);
 
     // copy buffers to output
@@ -762,36 +755,6 @@ void AudioManager::initInputBuffer(juce::Array<source_index_t> const & sources)
     mInputBuffer.init(sources);
 }
 
-#if SG_USE_FORK_UNION
-void AudioManager::initForkUnionBuffer([[maybe_unused]] int newBufferSize,
-                                       [[maybe_unused]] tl::optional<int> numSpeakers)
-{
-    #if SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS
-    if (numSpeakers.has_value())
-        forkUnionBuffer.resize(*numSpeakers);
-
-    for (int i = 0; i < numSpeakers; ++i) {
-        forkUnionBuffer[i].clear();
-        for (int j = 0; j < newBufferSize; ++j)
-            forkUnionBuffer[i].emplace_back(0.0f);
-    }
-    #elif SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD
-    // so we have a buffer for each hardware thread
-    auto const numThreads = std::thread::hardware_concurrency();
-    forkUnionBuffer.resize(numThreads);
-
-    for (auto & curThreadSpeakerBuffer : forkUnionBuffer) {
-        // then within each thread we need a buffer for each speaker
-        if (numSpeakers.has_value())
-            curThreadSpeakerBuffer.resize(*numSpeakers);
-
-        // and each speaker buffer contains bufferSize samples
-        for (auto & curSpeakerBuffer : curThreadSpeakerBuffer)
-            curSpeakerBuffer.assign(newBufferSize, 0.f);
-    }
-    #endif
-}
-#endif
 
 //==============================================================================
 void AudioManager::initOutputBuffer(juce::Array<output_patch_t> const & speakers)
@@ -801,9 +764,6 @@ void AudioManager::initOutputBuffer(juce::Array<output_patch_t> const & speakers
     juce::ScopedLock const lock{ mAudioProcessor->getLock() };
     mOutputBuffer.init(speakers);
 
-#if SG_USE_FORK_UNION
-    initForkUnionBuffer (SpeakerAudioBuffer::MAX_NUM_SAMPLES, speakers.size());
-#endif
 }
 
 //==============================================================================
@@ -816,9 +776,6 @@ void AudioManager::setBufferSize(int const newBufferSize)
     mOutputBuffer.setNumSamples(newBufferSize);
     mStereoOutputBuffer.setSize(2, newBufferSize);
 
-#if SG_USE_FORK_UNION
-    initForkUnionBuffer (newBufferSize, tl::nullopt);
-#endif
 }
 
 //==============================================================================

--- a/Source/sg_AudioManager.hpp
+++ b/Source/sg_AudioManager.hpp
@@ -82,9 +82,6 @@ private:
     juce::AudioDeviceManager mAudioDeviceManager{};
     SourceAudioBuffer mInputBuffer{};
     SpeakerAudioBuffer mOutputBuffer{};
-#if SG_USE_FORK_UNION && (SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS || SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD)
-    ForkUnionBuffer forkUnionBuffer;
-#endif
 
     juce::AudioBuffer<float> mStereoOutputBuffer{};
     tl::optional<StereoRouting> mStereoRouting{};
@@ -140,9 +137,6 @@ public:
     juce::Array<juce::File> & getAudioFiles();
 
     void initInputBuffer(juce::Array<source_index_t> const & sources);
-#if SG_USE_FORK_UNION
-    void initForkUnionBuffer (int bufferSize, tl::optional<int> speakerCount);
-#endif
     void initOutputBuffer(juce::Array<output_patch_t> const & speakers);
     void setBufferSize(int newBufferSize);
     void setStereoRouting(tl::optional<StereoRouting> const & stereoRouting);

--- a/Source/sg_AudioProcessor.cpp
+++ b/Source/sg_AudioProcessor.cpp
@@ -106,13 +106,6 @@ void AudioProcessor::processOutputModifiersAndPeaks(SpeakerAudioBuffer & speaker
 //==============================================================================
 void AudioProcessor::processAudio(SourceAudioBuffer & sourceBuffer,
                                   SpeakerAudioBuffer & speakerBuffer,
-#if SG_USE_FORK_UNION
-    #if SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS
-                                  ForkUnionBuffer & forkUnionBuffer,
-    #elif SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD
-                                  ForkUnionBuffer & forkUnionBuffer,
-    #endif
-#endif
                                   juce::AudioBuffer<float> & stereoBuffer) noexcept [[clang::nonblocking]]
 {
     // Skip if the user is editing the speaker setup.
@@ -142,9 +135,6 @@ void AudioProcessor::processAudio(SourceAudioBuffer & sourceBuffer,
         mSpatAlgorithm->process(*mAudioData.config,
                                 sourceBuffer,
                                 speakerBuffer,
-#if SG_USE_FORK_UNION && (SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS || SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD)
-                                forkUnionBuffer,
-#endif
                                 stereoBuffer,
                                 sourcePeaks,
                                 nullptr);

--- a/Source/sg_AudioProcessor.hpp
+++ b/Source/sg_AudioProcessor.hpp
@@ -47,13 +47,6 @@ public:
     [[nodiscard]] juce::CriticalSection const & getLock() const noexcept { return mLock; }
     void processAudio(SourceAudioBuffer & sourceBuffer,
                       SpeakerAudioBuffer & speakerBuffer,
-#if SG_USE_FORK_UNION
-    #if SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS
-                      ForkUnionBuffer & forkUnionBuffer,
-    #elif SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD
-                      ForkUnionBuffer & forkUnionBuffer,
-    #endif
-#endif
                       juce::AudioBuffer<float> & stereoBuffer) noexcept;
 
     auto & getAudioData() { return mAudioData; }
@@ -62,13 +55,6 @@ public:
     auto const & getSpatAlgorithm() const { return mSpatAlgorithm; }
     auto & getSpatAlgorithm() { return mSpatAlgorithm; }
 
-#if SG_USE_FORK_UNION && (SG_FU_METHOD == SG_FU_USE_ARRAY_OF_ATOMICS || SG_FU_METHOD == SG_FU_USE_BUFFER_PER_THREAD)
-    void silenceForkUnionBuffer(ForkUnionBuffer & forkUnionBuffer) noexcept
-    {
-        if (mSpatAlgorithm)
-            mSpatAlgorithm->silenceForkUnionBuffer(forkUnionBuffer);
-    }
-#endif
 
 private:
     //==============================================================================

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -175,8 +175,8 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     mCol2Layout.addSection(mAttenuationLayout).withFixedSize(ROW_1_CONTENT_HEIGHT).withBottomPadding(ROW_PADDING);
     mCol2Layout.addSection(mStereoRoutingLabel).withFixedSize(LABEL_HEIGHT);
 
-    mBottomLeftComponentSwapper.addComponent(multicoreDSPToggleName, &mMulticoreDSPToggle);
-    mBottomLeftComponentSwapper.addComponent(stereoRoutingLayoutName, &mStereoRoutingLayout);
+    mBottomLeftComponentSwapper.addComponent(multicoreDSPToggleName, juce::Component::SafePointer<juce::Component>(&mMulticoreDSPToggle));
+    mBottomLeftComponentSwapper.addComponent(stereoRoutingLayoutName,juce::Component::SafePointer<juce::Component>(&mStereoRoutingLayout));
     addAndMakeVisible(mBottomLeftComponentSwapper);
 
     mCol2Layout.addSection(mBottomLeftComponentSwapper).withFixedSize(ROW_2_CONTENT_HEIGHT);

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -100,8 +100,8 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
 
     auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip, bool isSpatModeRadioButton = true) {
         button.setClickingTogglesState(true);
-        if (isSpatModeRadioButton) {
-          button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);       }
+        if (isSpatModeRadioButton)
+            button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);
         button.setButtonText(text);
         button.setTooltip(tooltip);
         button.addListener(this);

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -98,9 +98,10 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
         label.setColour(juce::Label::ColourIds::textColourId, lookAndFeel.getFontColour());
     };
 
-    auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip) {
+    auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip, bool isSpatModeRadioButton = true) {
         button.setClickingTogglesState(true);
-        button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);
+        if (isSpatModeRadioButton)
+            button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);
         button.setButtonText(text);
         button.setTooltip(tooltip);
         button.addListener(this);
@@ -123,8 +124,6 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     initButton(mHybridButton, spatModeToString(SpatMode::hybrid), spatModeToTooltip(SpatMode::hybrid));
 
     initButton(mMulticoreDSPToggle, "Use Multicore DSP", "Experimental : This will use more CPU resources but can perform better on large speaker setups. Does not parallelize stereo or binaural reductions.");
-    // initButtons set this but we don't want the multicore button to be considered a radio button with the spat buttons..
-    mMulticoreDSPToggle.setRadioGroupId(0);
 
     juce::StringArray items{ "None" };
     items.addArray(STEREO_MODE_STRINGS);

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -100,8 +100,8 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
 
     auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip, bool isSpatModeRadioButton = true) {
         button.setClickingTogglesState(true);
-        if (isSpatModeRadioButton)
-            button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);
+        if (isSpatModeRadioButton) {
+          button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);       }
         button.setButtonText(text);
         button.setTooltip(tooltip);
         button.addListener(this);
@@ -123,7 +123,7 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     initButton(mCubeButton, spatModeToString(SpatMode::mbap), spatModeToTooltip(SpatMode::mbap));
     initButton(mHybridButton, spatModeToString(SpatMode::hybrid), spatModeToTooltip(SpatMode::hybrid));
 
-    initButton(mMulticoreDSPToggle, "Use Multicore DSP", "Experimental : This will use more CPU resources but can perform better on large speaker setups. Does not parallelize stereo or binaural reductions.");
+    initButton(mMulticoreDSPToggle, "Use Multicore DSP", "Experimental : This will use more CPU resources but can perform better on large speaker setups. Does not parallelize stereo or binaural reductions.", false);
 
     juce::StringArray items{ "None" };
     items.addArray(STEREO_MODE_STRINGS);

--- a/Source/sg_ControlPanel.hpp
+++ b/Source/sg_ControlPanel.hpp
@@ -108,6 +108,8 @@ class SpatSettingsSubPanel final
     juce::Label mStereoReductionLabel{};
     juce::Label mStereoRoutingLabel{};
 
+    juce::TextButton mMulticoreDSPToggle{};
+
     juce::ComboBox mStereoReductionCombo{};
 
     juce::Label mLeftLabel{};

--- a/Source/sg_ControlPanel.hpp
+++ b/Source/sg_ControlPanel.hpp
@@ -93,6 +93,7 @@ class SpatSettingsSubPanel final
     LayoutComponent mCol2Layout{ LayoutComponent::Orientation::vertical, false, false, mLookAndFeel };
     LayoutComponent mAttenuationLayout{ LayoutComponent::Orientation::horizontal, false, false, mLookAndFeel };
     LayoutComponent mStereoRoutingLayout{ LayoutComponent::Orientation::horizontal, false, false, mLookAndFeel };
+    const std::string stereoRoutingLayoutName{"stereo routing layout"};
 
     juce::Label mAlgorithmSelectionLabel{};
     juce::Label mAttenuationSettingsLabel{};
@@ -108,9 +109,15 @@ class SpatSettingsSubPanel final
     juce::Label mStereoReductionLabel{};
     juce::Label mStereoRoutingLabel{};
 
-    juce::TextButton mMulticoreDSPToggle{};
+
 
     juce::ComboBox mStereoReductionCombo{};
+    juce::TextButton mMulticoreDSPToggle{};
+    const std::string multicoreDSPToggleName{"multicore dsp toggle"};
+    /**
+     * Used to swap the multicore DSP toggle and the stereo routing dropdowns.
+     */
+    SwappableComponent mBottomLeftComponentSwapper{};
 
     juce::Label mLeftLabel{};
     juce::ComboBox mLeftCombo{};
@@ -128,6 +135,7 @@ public:
     void updateMaxOutputPatch(output_patch_t maxOutputPatch, StereoRouting const & routing);
     //==============================================================================
     void setSpatMode(SpatMode spatMode);
+    void setMulticoreDSP(bool useMulticoreDSP);
     void setStereoMode(tl::optional<StereoMode> const & stereoMode);
     void setAttenuationDb(dbfs_t attenuation);
     void setAttenuationHz(hz_t freq);
@@ -179,6 +187,7 @@ public:
     void setMasterGain(dbfs_t gain);
     void setInterpolation(float interpolation);
     void setSpatMode(SpatMode spatMode);
+    void setMulticoreDSP(bool useMulticoreDSP);
     void setStereoMode(tl::optional<StereoMode> const & mode);
     void setCubeAttenuationDb(dbfs_t value);
     void setCubeAttenuationHz(hz_t value);

--- a/Source/sg_LayoutComponent.cpp
+++ b/Source/sg_LayoutComponent.cpp
@@ -393,13 +393,18 @@ int LayoutComponent::getMinInnerHeight() const noexcept
     });
 }
 
-void SwappableComponent::addComponent(const std::string& name, juce::Component* component) {
+void SwappableComponent::addComponent(const std::string& name, juce::Component::SafePointer<juce::Component> component) {
     components[name] = component;
-    addAndMakeVisible(*component);
+    if (component) {
+        addAndMakeVisible(*component);
+    }
 }
 
 void SwappableComponent::showComponent(const std::string& name) {
     for (auto& [key, component] : components) {
+        if (!component) {
+            continue;
+        }
         if (key != name) {
             component->setVisible(false);
         } else {
@@ -409,8 +414,11 @@ void SwappableComponent::showComponent(const std::string& name) {
 }
 
 void SwappableComponent::resized() {
-    for (auto& [key, component] : components)
-        component->setBounds(getLocalBounds());
+    for (auto& [key, component] : components) {
+        if (component) {
+            component->setBounds(getLocalBounds());
+        }
+    }
 }
 
 } // namespace gris

--- a/Source/sg_LayoutComponent.cpp
+++ b/Source/sg_LayoutComponent.cpp
@@ -393,4 +393,24 @@ int LayoutComponent::getMinInnerHeight() const noexcept
     });
 }
 
+void SwappableComponent::addComponent(const std::string& name, juce::Component* component) {
+    components[name] = component;
+    addAndMakeVisible(*component);
+}
+
+void SwappableComponent::showComponent(const std::string& name) {
+    for (auto& [key, component] : components) {
+        if (key != name) {
+            component->setVisible(false);
+        } else {
+            component->setVisible(true);
+        }
+    }
+}
+
+void SwappableComponent::resized() {
+    for (auto& [key, component] : components)
+        component->setBounds(getLocalBounds());
+}
+
 } // namespace gris

--- a/Source/sg_LayoutComponent.hpp
+++ b/Source/sg_LayoutComponent.hpp
@@ -116,17 +116,16 @@ private:
  * LayoutComponent class so we provide this helper to which you can add components and
  * swap between them by name.
  *
- * This uses raw pointers, be careful.
  */
 class SwappableComponent final
     : public juce::Component
 {
   public:
-    void addComponent(const std::string& name, juce::Component* comp);
+    void addComponent(const std::string& name, juce::Component::SafePointer<juce::Component> comp);
     void showComponent(const std::string& name);
     void resized() override;
   private:
-    std::map<std::string, juce::Component*> components;
+    std::map<std::string, juce::Component::SafePointer<juce::Component>> components;
     JUCE_LEAK_DETECTOR(SwappableComponent)
 };
 

--- a/Source/sg_LayoutComponent.hpp
+++ b/Source/sg_LayoutComponent.hpp
@@ -110,4 +110,24 @@ private:
     JUCE_LEAK_DETECTOR(LayoutComponent)
 };
 
+/**
+ * With normal juce layouting, to swap two components, we would define two components
+ * with the same bound and just show/hide them. This is harder to do with the custom
+ * LayoutComponent class so we provide this helper to which you can add components and
+ * swap between them by name.
+ *
+ * This uses raw pointers, be careful.
+ */
+class SwappableComponent final
+    : public juce::Component
+{
+  public:
+    void addComponent(const std::string& name, juce::Component* comp);
+    void showComponent(const std::string& name);
+    void resized() override;
+  private:
+    std::map<std::string, juce::Component*> components;
+    JUCE_LEAK_DETECTOR(SwappableComponent)
+};
+
 } // namespace gris

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -159,6 +159,11 @@ MainContentComponent::MainContentComponent(MainWindow & mainWindow,
         // Control panel
         mControlPanel = std::make_unique<ControlPanel>(*this, mLookAndFeel);
         mControlsSection = std::make_unique<TitledComponent>("Controls", mControlPanel.get(), mLookAndFeel);
+
+        // Note : mData.project is not loaded yet at this point. You can't rely on
+        // the values it contains.
+        mControlPanel->setMulticoreDSP(mData.project.useMulticoreDSP);
+        mControlPanel->setSpatMode(mData.project.spatMode);
         mControlPanel->setSpatMode(mData.project.spatMode);
         mControlPanel->setCubeAttenuationDb(mData.project.mbapDistanceAttenuationData.attenuation);
         mControlPanel->setCubeAttenuationHz(mData.project.mbapDistanceAttenuationData.freq);
@@ -257,13 +262,22 @@ MainContentComponent::MainContentComponent(MainWindow & mainWindow,
     // Load app config
     showSplashScreen();
     initAppData();
+
+    // TODO one day : initGui tries to set default values to buttons and other such things
+    // but a lot of those values are read from the project, which is initialized in initProject
+    // later. This means initGui has wrong values for a a lot of things and we need to a add
+    // gui init stuff *after* initProject. We can't trivialy reorder those but I don't remember
+    // why.
     initGui();
     initProject();
+
+    // This section contains gui initializations that need a loaded project.
 
     // SpeakerViewComponent 3D view (need project data before initialization)
     mSpeakerViewComponent.reset(new SpeakerViewComponent(*this));
     mSpeakerViewComponent->setCameraPosition(mData.appData.cameraPosition);
     handleShowSpeakerViewWindow();
+    mControlPanel->setMulticoreDSP(mData.project.useMulticoreDSP);
 
     initSpeakerSetup();
     initAudioManager();
@@ -1716,6 +1730,7 @@ bool MainContentComponent::isProjectModified() const
     if (!savedProject) {
         return true;
     }
+
     return mData.project != *savedProject;
 }
 
@@ -2363,6 +2378,7 @@ void MainContentComponent::refreshSpatAlgorithm()
     juce::ScopedLock const audioLock{ mAudioProcessor->getLock() };
 
     auto & oldSpatAlgorithm{ mAudioProcessor->getSpatAlgorithm() };
+
     auto newSpatAlgorithm{ AbstractSpatAlgorithm::make(mData.speakerSetup,
                                                        mData.project.spatMode,
                                                        mData.appData.stereoMode,

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -162,6 +162,7 @@ MainContentComponent::MainContentComponent(MainWindow & mainWindow,
 
         // Note : mData.project is not loaded yet at this point. You can't rely on
         // the values it contains.
+        // TODO : fix this.
         mControlPanel->setMulticoreDSP(mData.project.useMulticoreDSP);
         mControlPanel->setSpatMode(mData.project.spatMode);
         mControlPanel->setSpatMode(mData.project.spatMode);

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2363,7 +2363,8 @@ void MainContentComponent::refreshSpatAlgorithm()
                                                        mData.appData.stereoMode,
                                                        mData.project.sources,
                                                        mData.appData.audioSettings.sampleRate,
-                                                       mData.appData.audioSettings.bufferSize) };
+                                                       mData.appData.audioSettings.bufferSize,
+                                                       mData.project.useMulticoreDSP) };
 
     if (newSpatAlgorithm->getError()
         && (!oldSpatAlgorithm || oldSpatAlgorithm->getError() != newSpatAlgorithm->getError())) {

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -920,6 +920,11 @@ void MainContentComponent::setSpatMode(SpatMode const spatMode)
     refreshSpeakers();
 }
 
+void MainContentComponent::setMulticoreDSPState(const bool state) {
+    mData.project.useMulticoreDSP = state;
+    refreshSpatAlgorithm();
+}
+
 //==============================================================================
 void MainContentComponent::setStereoMode(tl::optional<StereoMode> const stereoMode)
 {

--- a/Source/sg_MainComponent.hpp
+++ b/Source/sg_MainComponent.hpp
@@ -227,6 +227,7 @@ public:
     //==============================================================================
     // Control Panel
     void setSpatMode(SpatMode const spatMode);
+    void setMulticoreDSPState(bool const state);
     void setStereoMode(tl::optional<StereoMode> stereoMode);
     void setStereoRouting(StereoRouting const & routing);
     void cubeAttenuationDbChanged(dbfs_t value);

--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -238,6 +238,14 @@
     </GROUP>
     <GROUP id="{755DB51A-2CFD-1B50-3D92-CF35F1E89E3D}" name="submodules">
       <GROUP id="{1FBCD2DD-9050-30FD-E1BE-E07C1F83877B}" name="AlgoGRIS">
+        <FILE id="ZvEAgD" name="sg_ParallelVbapSpatAlgorithm.cpp" compile="1"
+              resource="0" file="submodules/AlgoGRIS/sg_ParallelVbapSpatAlgorithm.cpp"/>
+        <FILE id="qc0Xkd" name="sg_ParallelVbapSpatAlgorithm.hpp" compile="0"
+              resource="0" file="submodules/AlgoGRIS/sg_ParallelVbapSpatAlgorithm.hpp"/>
+        <FILE id="vebF0a" name="sg_ParallelMbapSpatAlgorithm.cpp" compile="1"
+              resource="0" file="submodules/AlgoGRIS/sg_ParallelMbapSpatAlgorithm.cpp"/>
+        <FILE id="ZjvJRR" name="sg_ParallelMbapSpatAlgorithm.hpp" compile="0"
+              resource="0" file="submodules/AlgoGRIS/sg_ParallelMbapSpatAlgorithm.hpp"/>
         <GROUP id="{A45D1137-A159-7D72-0988-A5D9CD18249A}" name="submodules">
           <GROUP id="{7E5D6A36-608D-6F84-EB57-694120F99FAC}" name="StructGRIS">
             <GROUP id="{A324FA3A-41AE-A94A-2925-6D244656F392}" name="Containers">
@@ -348,8 +356,6 @@
               file="submodules/AlgoGRIS/sg_HrtfSpatAlgorithm.cpp"/>
         <FILE id="X5DiSM" name="sg_HrtfSpatAlgorithm.hpp" compile="0" resource="0"
               file="submodules/AlgoGRIS/sg_HrtfSpatAlgorithm.hpp"/>
-        <FILE id="WH2cPI" name="sg_HybridSpatAlgorithm.cpp" compile="1" resource="0"
-              file="submodules/AlgoGRIS/sg_HybridSpatAlgorithm.cpp"/>
         <FILE id="GTiaFP" name="sg_HybridSpatAlgorithm.hpp" compile="0" resource="0"
               file="submodules/AlgoGRIS/sg_HybridSpatAlgorithm.hpp"/>
         <FILE id="ha7T9L" name="sg_MbapSpatAlgorithm.cpp" compile="1" resource="0"


### PR DESCRIPTION
This builds on the work of @vberthiaume to polish `fork_union` integration in the spatialization algorithms.

Since parallel processing increases resource usage across the board and it may have different latency characteristic due to using a sleep() in the threadpool (necessary to not use 100%CPU at all time), I made it opt in with a new button in the interface.

Speedups can go from about 20% up to 100% depending on the use case. In my empirical testing I have been able to run 256 sources with active audio, high elevation and amplitude spans and constant motion through a speaker setup with 60 speakers with the MBAP algorithm without missing samples. The same setup did not work without the parallel processing.

This depends on two other PRs in algoGRIS and structGRIS