### PR TITLE
Improve multicore dsp

### DIFF
--- a/.github/workflows/SpatGris-builds.yml
+++ b/.github/workflows/SpatGris-builds.yml
@@ -259,7 +259,7 @@ jobs:
         run: |
           submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/extras/Projucer/Builds/VisualStudio2022/x64/Release/App/Projucer.exe --resave SpatGRIS.jucer
       - name: Build SpatGRIS
-        run: msbuild Builds/VisualStudio2022/SpatGRIS_App.vcxproj -p:Configuration=Release -p:Platform=x64 -p:IncludePath=../../asiosdk_2.3.3_2019-06-14/common/
+        run: msbuild Builds/VisualStudio2022/SpatGRIS_App.vcxproj -p:Configuration=Release -p:Platform=x64 -p:IncludePath=../../ASIOSDK/common/
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -98,10 +98,10 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
         label.setColour(juce::Label::ColourIds::textColourId, lookAndFeel.getFontColour());
     };
 
-    auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip, bool isSpatModeRadioButton = true) {
+    auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip, int radioButtonId = SPAT_MODE_BUTTONS_RADIO_GROUP_ID) {
         button.setClickingTogglesState(true);
-        if (isSpatModeRadioButton)
-            button.setRadioGroupId(SPAT_MODE_BUTTONS_RADIO_GROUP_ID, juce::dontSendNotification);
+        if (radioButtonId)
+            button.setRadioGroupId(radioButtonId, juce::dontSendNotification);
         button.setButtonText(text);
         button.setTooltip(tooltip);
         button.addListener(this);
@@ -110,6 +110,7 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     initLabel(mAlgorithmSelectionLabel, "Algorithm selection");
     initLabel(mStereoReductionLabel, "Stereo reduction");
     initLabel(mStereoRoutingLabel, "Stereo routing");
+    initLabel(mMulticoreLabel, "Multicore DSP Settings");
     initLabel(mLeftLabel, "Left :", juce::Justification::topRight);
     initLabel(mRightLabel, "Right :", juce::Justification::topRight);
 
@@ -123,7 +124,9 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     initButton(mCubeButton, spatModeToString(SpatMode::mbap), spatModeToTooltip(SpatMode::mbap));
     initButton(mHybridButton, spatModeToString(SpatMode::hybrid), spatModeToTooltip(SpatMode::hybrid));
 
-    initButton(mMulticoreDSPToggle, "Use Multicore DSP", "Experimental : This will use more CPU resources but can perform better on large speaker setups. Does not parallelize stereo or binaural reductions.", false);
+    initButton(mMulticoreDSPToggle, "Multicore DSP", "Experimental : This will use more CPU resources but can perform better on large speaker setups. Does not parallelize stereo or binaural reductions.", NOT_A_RADIO_BUTTON_ID);
+    initButton(mMulticoreDSPCPUPresetToggle, "A", "This preset uses less idle CPU but can perform worse.", MULTICORE_PRESETS_RADIO_GROUP_ID);
+    initButton(mMulticoreDSPLatencyPresetToggle, "B", "This preset uses more idle CPU but can perform better.", MULTICORE_PRESETS_RADIO_GROUP_ID);
 
     juce::StringArray items{ "None" };
     items.addArray(STEREO_MODE_STRINGS);
@@ -169,13 +172,19 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     mStereoRoutingLayout.addSection(mRightLabel).withFixedSize(COL_2_QUARTER_WIDTH);
     mStereoRoutingLayout.addSection(mRightCombo).withFixedSize(COL_2_QUARTER_WIDTH);
 
-
+    mMulticoreLayout.addSection(mMulticoreDSPToggle).withFixedSize(COL_2_HALF_WIDTH);
+    mMulticoreLayout.addSection(mMulticoreDSPCPUPresetToggle).withFixedSize(COL_2_QUARTER_WIDTH);
+    mMulticoreLayout.addSection(mMulticoreDSPLatencyPresetToggle).withFixedSize(COL_2_QUARTER_WIDTH);
 
     mCol2Layout.addSection(mAttenuationSettingsButton).withFixedSize(LABEL_HEIGHT);
     mCol2Layout.addSection(mAttenuationLayout).withFixedSize(ROW_1_CONTENT_HEIGHT).withBottomPadding(ROW_PADDING);
-    mCol2Layout.addSection(mStereoRoutingLabel).withFixedSize(LABEL_HEIGHT);
 
-    mBottomLeftComponentSwapper.addComponent(multicoreDSPToggleName, juce::Component::SafePointer<juce::Component>(&mMulticoreDSPToggle));
+    mTopLeftComponentSwapper.addComponent(multicoreLabelName, juce::Component::SafePointer<juce::Component>(&mMulticoreLabel));
+    mTopLeftComponentSwapper.addComponent(stereoRoutingLabelName, juce::Component::SafePointer<juce::Component>(&mStereoRoutingLabel));
+
+    mCol2Layout.addSection(mTopLeftComponentSwapper).withFixedSize(LABEL_HEIGHT);
+
+    mBottomLeftComponentSwapper.addComponent(multicoreLayoutName, juce::Component::SafePointer<juce::Component>(&mMulticoreLayout));
     mBottomLeftComponentSwapper.addComponent(stereoRoutingLayoutName,juce::Component::SafePointer<juce::Component>(&mStereoRoutingLayout));
     addAndMakeVisible(mBottomLeftComponentSwapper);
 
@@ -280,6 +289,15 @@ void SpatSettingsSubPanel::setMulticoreDSP(bool useMulticoreDSP)
     mMulticoreDSPToggle.setToggleState(useMulticoreDSP, juce::dontSendNotification);
 }
 
+void SpatSettingsSubPanel::setMulticoreDSPPreset(int preset)
+{
+    if (preset == OPTIMIZE_CPU_MULTICORE_PRESET) {
+        mMulticoreDSPCPUPresetToggle.setToggleState(true, juce::dontSendNotification);
+    } else if (preset == OPTIMIZE_LATENCY_MULTICORE_PRESET) {
+        mMulticoreDSPLatencyPresetToggle.setToggleState(true, juce::dontSendNotification);
+    }
+    JUCE_ASSERT_MESSAGE_THREAD;
+}
 
 //==============================================================================
 void SpatSettingsSubPanel::setStereoMode(tl::optional<StereoMode> const & stereoMode)
@@ -380,17 +398,20 @@ void SpatSettingsSubPanel::updateLayout()
 
     mStereoRoutingLabel.setVisible(showRouting);
 
-    // We may have previously set the visibility of this to false.
+    // We may have previously set the visibility of these to false.
     mBottomLeftComponentSwapper.setVisible(true);
-
+    mTopLeftComponentSwapper.setVisible(true);
     if (showRouting) {
         mBottomLeftComponentSwapper.showComponent(stereoRoutingLayoutName);
+        mTopLeftComponentSwapper.showComponent(stereoRoutingLabelName);
     } // we should not show the multicoreDSPToggle in hybrid mode because it should have no effect.
     else if (getSpatMode() != SpatMode::hybrid) {
-        mBottomLeftComponentSwapper.showComponent(multicoreDSPToggleName);
+        mBottomLeftComponentSwapper.showComponent(multicoreLayoutName);
+        mTopLeftComponentSwapper.showComponent(multicoreLabelName);
     } else {
         // if we are in hybrid mode and we should not show routing, hide everything.
         mBottomLeftComponentSwapper.setVisible(false);
+        mTopLeftComponentSwapper.setVisible(false);
     }
 
     clearSections();
@@ -424,6 +445,10 @@ void SpatSettingsSubPanel::buttonClicked(juce::Button * button)
         mControlPanel.forceLayoutUpdate();
     } else if (button == &mMulticoreDSPToggle) {
         mMainContentComponent.setMulticoreDSPState(button->getToggleState());
+    } else if (button == &mMulticoreDSPCPUPresetToggle && button->getToggleState()) {
+        mMainContentComponent.setMulticoreDSPPreset(OPTIMIZE_CPU_MULTICORE_PRESET);
+    } else if (button == &mMulticoreDSPLatencyPresetToggle && button->getToggleState()) {
+        mMainContentComponent.setMulticoreDSPPreset(OPTIMIZE_LATENCY_MULTICORE_PRESET);
     }
 }
 
@@ -536,6 +561,12 @@ void ControlPanel::setMulticoreDSP(bool useMulticoreDSP)
     JUCE_ASSERT_MESSAGE_THREAD;
     mSpatSettingsSubPanel.setMulticoreDSP(useMulticoreDSP);
 }
+void ControlPanel::setMulticoreDSPPreset(int preset)
+{
+    JUCE_ASSERT_MESSAGE_THREAD;
+    mSpatSettingsSubPanel.setMulticoreDSPPreset(preset);
+}
+
 
 //==============================================================================
 void ControlPanel::setStereoMode(tl::optional<StereoMode> const & mode)

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -380,10 +380,17 @@ void SpatSettingsSubPanel::updateLayout()
 
     mStereoRoutingLabel.setVisible(showRouting);
 
+    // We may have previously set the visibility of this to false.
+    mBottomLeftComponentSwapper.setVisible(true);
+
     if (showRouting) {
         mBottomLeftComponentSwapper.showComponent(stereoRoutingLayoutName);
-    } else {
+    } // we should not show the multicoreDSPToggle in hybrid mode because it should have no effect.
+    else if (getSpatMode() != SpatMode::hybrid) {
         mBottomLeftComponentSwapper.showComponent(multicoreDSPToggleName);
+    } else {
+        // if we are in hybrid mode and we should not show routing, hide everything.
+        mBottomLeftComponentSwapper.setVisible(false);
     }
 
     clearSections();

--- a/Source/sg_ControlPanel.hpp
+++ b/Source/sg_ControlPanel.hpp
@@ -95,6 +95,10 @@ class SpatSettingsSubPanel final
     LayoutComponent mStereoRoutingLayout{ LayoutComponent::Orientation::horizontal, false, false, mLookAndFeel };
     const std::string stereoRoutingLayoutName{"stereo routing layout"};
 
+    LayoutComponent mMulticoreLayout{ LayoutComponent::Orientation::horizontal, false, false, mLookAndFeel };
+    const std::string multicoreLayoutName{"multicore routing layout"};
+
+
     juce::Label mAlgorithmSelectionLabel{};
     juce::Label mAttenuationSettingsLabel{};
     juce::ToggleButton mAttenuationSettingsButton{ "Attenuation settings" };
@@ -103,21 +107,31 @@ class SpatSettingsSubPanel final
     juce::TextButton mCubeButton{};
     juce::TextButton mHybridButton{};
 
+    juce::Label mMulticoreLabel{};
+    const std::string multicoreLabelName{"multicore label"};
+
     juce::ComboBox mAttenuationDbCombo{};
     juce::ComboBox mAttenuationHzCombo{};
 
     juce::Label mStereoReductionLabel{};
     juce::Label mStereoRoutingLabel{};
+    const std::string stereoRoutingLabelName{"stereo routing label"};
 
 
 
     juce::ComboBox mStereoReductionCombo{};
     juce::TextButton mMulticoreDSPToggle{};
-    const std::string multicoreDSPToggleName{"multicore dsp toggle"};
+    juce::TextButton mMulticoreDSPCPUPresetToggle{};
+    juce::TextButton mMulticoreDSPLatencyPresetToggle{};
     /**
-     * Used to swap the multicore DSP toggle and the stereo routing dropdowns.
+     * Used to swap the multicore DSP toggles and the stereo routing dropdowns.
      */
     SwappableComponent mBottomLeftComponentSwapper{};
+    /**
+     * Used to swap between the multicore DSP label and the stereo routing label.
+     */
+    SwappableComponent mTopLeftComponentSwapper{};
+
 
     juce::Label mLeftLabel{};
     juce::ComboBox mLeftCombo{};
@@ -136,6 +150,7 @@ public:
     //==============================================================================
     void setSpatMode(SpatMode spatMode);
     void setMulticoreDSP(bool useMulticoreDSP);
+    void setMulticoreDSPPreset(int preset);
     void setStereoMode(tl::optional<StereoMode> const & stereoMode);
     void setAttenuationDb(dbfs_t attenuation);
     void setAttenuationHz(hz_t freq);
@@ -145,6 +160,10 @@ public:
     [[nodiscard]] tl::optional<StereoMode> getStereoMode() const;
 
 private:
+    // TODO: the other radio button constants are in StructGRIS but I really don't think they
+    // need to be common between SpatGRIS and AlgoGRIS. These belong in a SpatGRIS constant file somewhere.
+    static constexpr auto MULTICORE_PRESETS_RADIO_GROUP_ID = 4;
+    static constexpr auto NOT_A_RADIO_BUTTON_ID = 0;
     //==============================================================================
     [[nodiscard]] SpatMode getSpatMode() const;
     [[nodiscard]] bool shouldShowAttenuationSettings() const;
@@ -188,6 +207,7 @@ public:
     void setInterpolation(float interpolation);
     void setSpatMode(SpatMode spatMode);
     void setMulticoreDSP(bool useMulticoreDSP);
+    void setMulticoreDSPPreset(int preset);
     void setStereoMode(tl::optional<StereoMode> const & mode);
     void setCubeAttenuationDb(dbfs_t value);
     void setCubeAttenuationHz(hz_t value);

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2380,13 +2380,17 @@ void MainContentComponent::refreshSpatAlgorithm()
 
     auto & oldSpatAlgorithm{ mAudioProcessor->getSpatAlgorithm() };
 
+    // AbstractSpatAlgorithm::make can make a hybrid mode algorithm with multicore dsp
+    // enable but this has been benchmarked to be less performant than single core.
+    const bool shouldUseMulticoreDSP = mData.project.useMulticoreDSP && mData.project.spatMode != SpatMode::hybrid;
+
     auto newSpatAlgorithm{ AbstractSpatAlgorithm::make(mData.speakerSetup,
                                                        mData.project.spatMode,
                                                        mData.appData.stereoMode,
                                                        mData.project.sources,
                                                        mData.appData.audioSettings.sampleRate,
                                                        mData.appData.audioSettings.bufferSize,
-                                                       mData.project.useMulticoreDSP) };
+                                                       shouldUseMulticoreDSP) };
 
     if (newSpatAlgorithm->getError()
         && (!oldSpatAlgorithm || oldSpatAlgorithm->getError() != newSpatAlgorithm->getError())) {

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -27,6 +27,7 @@
 #include "sg_GrisLookAndFeel.hpp"
 #include "Data/sg_LegacyLbapPosition.hpp"
 #include "sg_MainWindow.hpp"
+#include "sg_ParallelSpatAlgorithm.hpp"
 #include "sg_ScopeGuard.hpp"
 #include "sg_TitledComponent.hpp"
 #include "Data/sg_constants.hpp"
@@ -164,6 +165,7 @@ MainContentComponent::MainContentComponent(MainWindow & mainWindow,
         // the values it contains.
         // TODO : fix this.
         mControlPanel->setMulticoreDSP(mData.project.useMulticoreDSP);
+        mControlPanel->setMulticoreDSPPreset(mData.project.multicoreDSPPreset);
         mControlPanel->setSpatMode(mData.project.spatMode);
         mControlPanel->setSpatMode(mData.project.spatMode);
         mControlPanel->setCubeAttenuationDb(mData.project.mbapDistanceAttenuationData.attenuation);
@@ -279,6 +281,7 @@ MainContentComponent::MainContentComponent(MainWindow & mainWindow,
     mSpeakerViewComponent->setCameraPosition(mData.appData.cameraPosition);
     handleShowSpeakerViewWindow();
     mControlPanel->setMulticoreDSP(mData.project.useMulticoreDSP);
+    mControlPanel->setMulticoreDSPPreset(mData.project.multicoreDSPPreset);
 
     initSpeakerSetup();
     initAudioManager();
@@ -938,6 +941,12 @@ void MainContentComponent::setSpatMode(SpatMode const spatMode)
 void MainContentComponent::setMulticoreDSPState(const bool state) {
     mData.project.useMulticoreDSP = state;
     refreshSpatAlgorithm();
+}
+
+void MainContentComponent::setMulticoreDSPPreset(int preset) {
+    mData.project.multicoreDSPPreset = preset;
+    // no need to refresh the spat algorithm for this. It only sets worker thread waiting policy.
+    SpinSleepWait::setPerformancePreset(preset);
 }
 
 //==============================================================================
@@ -2383,6 +2392,9 @@ void MainContentComponent::refreshSpatAlgorithm()
     // AbstractSpatAlgorithm::make can make a hybrid mode algorithm with multicore dsp
     // enable but this has been benchmarked to be less performant than single core.
     const bool shouldUseMulticoreDSP = mData.project.useMulticoreDSP && mData.project.spatMode != SpatMode::hybrid;
+
+    // necessary to have the right preset at project initialization.
+    SpinSleepWait::setPerformancePreset(mData.project.multicoreDSPPreset);
 
     auto newSpatAlgorithm{ AbstractSpatAlgorithm::make(mData.speakerSetup,
                                                        mData.project.spatMode,

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -457,7 +457,7 @@ bool MainContentComponent::loadProject(juce::File const & file, bool const disca
     mControlPanel->setMulticoreDSPPreset(mData.project.multicoreDSPPreset);
 
     setMulticoreDSPState(mData.project.useMulticoreDSP);
-    setMulticoreDSPPreset(mData.project.multicoreDSPPreset)
+    setMulticoreDSPPreset(mData.project.multicoreDSPPreset);
 
     refreshAudioProcessor();
     refreshViewportConfig();

--- a/Source/sg_MainComponent.hpp
+++ b/Source/sg_MainComponent.hpp
@@ -43,7 +43,6 @@
 #include "sg_SpeakerViewComponent.hpp"
 #include "sg_StereoSliceComponent.hpp"
 #include "sg_TitledComponent.hpp"
-
 namespace gris
 {
 class MainWindow;
@@ -228,6 +227,7 @@ public:
     // Control Panel
     void setSpatMode(SpatMode const spatMode);
     void setMulticoreDSPState(bool const state);
+    void setMulticoreDSPPreset(int preset);
     void setStereoMode(tl::optional<StereoMode> stereoMode);
     void setStereoRouting(StereoRouting const & routing);
     void cubeAttenuationDbChanged(dbfs_t value);

--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -238,6 +238,10 @@
     </GROUP>
     <GROUP id="{755DB51A-2CFD-1B50-3D92-CF35F1E89E3D}" name="submodules">
       <GROUP id="{1FBCD2DD-9050-30FD-E1BE-E07C1F83877B}" name="AlgoGRIS">
+        <FILE id="crzhzv" name="sg_ParallelSpatAlgorithm.cpp" compile="1" resource="0"
+              file="submodules/AlgoGRIS/sg_ParallelSpatAlgorithm.cpp"/>
+        <FILE id="IrsK2x" name="sg_ParallelSpatAlgorithm.hpp" compile="0" resource="0"
+              file="submodules/AlgoGRIS/sg_ParallelSpatAlgorithm.hpp"/>
         <FILE id="ZvEAgD" name="sg_ParallelVbapSpatAlgorithm.cpp" compile="1"
               resource="0" file="submodules/AlgoGRIS/sg_ParallelVbapSpatAlgorithm.cpp"/>
         <FILE id="qc0Xkd" name="sg_ParallelVbapSpatAlgorithm.hpp" compile="0"


### PR DESCRIPTION
This improves the multicore DSP feature in several ways:
- It generally improves performance with the added spin/sleep thread wait strategy
- It disables multicore DSP for hybrid mode which was benchmarked to be worse in every permutation I could think of
- It adds a preset selection
   - preset A uses less CPU but may have slightly worse performance
   - preset B uses more CPU but may have slightly better performance

What we have seen in tests with this PR and with multicore DSP

- Low buffer length (lower than 64 or 128 buffers depending on the machine) is worse with multicore
    - This is probably because the threads do not wake up fast enough to keep up with the latency requirements of low buffers
- For higher buffer lengths (maybe 64 and 128 and up), multicore can perform better than monocore. I have succeeded in playing 128 sources with active trajectories and active signal on the satosphere cube preset (90+ speakers) with the MBAP algorithm without glitches on a mac studio M2.  
