### PR TITLE
Fix clang and gcc warnings

### DIFF
--- a/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerSetupContainer.cpp
@@ -144,7 +144,7 @@ const juce::ValueTree& SpeakerSetupContainer::getSpeakerSetupVt() {
 juce::ValueTree SpeakerSetupContainer::getSelectedItem()
 {
     //if we have a selection, return the last selected item. Otherwise return the last overall item
-    if (auto const numSelected{ speakerSetupTreeView.getNumSelectedItems() }) {
+    if (speakerSetupTreeView.getNumSelectedItems()) {
         if (auto const selected = dynamic_cast<SpeakerSetupLine *>(speakerSetupTreeView.getSelectedItem(0)))
             return selected->getValueTree();
     } else {

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
@@ -430,8 +430,8 @@ void SpeakerGroupComponent::resized()
         const auto windowOriginInThis = window->getLocalPoint(this, juce::Point<int>{ 0, 0 });
         groupSettingsButton.setBounds(bounds.removeFromLeft(groupSettingsButtonWidth));
 
-        const auto idColWidth = fixedLeftColWidth - groupSettingsButtonWidth - static_cast<int>(windowOriginInThis.x);
-        id.setBounds(bounds.removeFromLeft(static_cast<int>(idColWidth - colGap)));
+        const int idColWidth = fixedLeftColWidth - groupSettingsButtonWidth - windowOriginInThis.x;
+        id.setBounds(bounds.removeFromLeft(idColWidth - colGap));
         bounds.removeFromLeft (colGap);
 
         // then position the other components with a fixed width of otherColWidth

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.cpp
@@ -430,8 +430,8 @@ void SpeakerGroupComponent::resized()
         const auto windowOriginInThis = window->getLocalPoint(this, juce::Point<int>{ 0, 0 });
         groupSettingsButton.setBounds(bounds.removeFromLeft(groupSettingsButtonWidth));
 
-        const auto idColWidth = fixedLeftColWidth - groupSettingsButtonWidth - windowOriginInThis.x;
-        id.setBounds(bounds.removeFromLeft(idColWidth - colGap));
+        const auto idColWidth = fixedLeftColWidth - groupSettingsButtonWidth - static_cast<int>(windowOriginInThis.x);
+        id.setBounds(bounds.removeFromLeft(static_cast<int>(idColWidth - colGap)));
         bounds.removeFromLeft (colGap);
 
         // then position the other components with a fixed width of otherColWidth

--- a/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.hpp
+++ b/Source/UI/Windows/SpeakerSetup/SpeakerTreeComponent.hpp
@@ -157,7 +157,7 @@ protected:
   void deleteButtonBehaviour() override;
   void setVbapSphericalCoordinateBehaviour() override;
 private:
-    static constexpr uint32_t groupSettingsButtonWidth = 20;
+    static constexpr int groupSettingsButtonWidth = 20;
     juce::ImageButton groupSettingsButton;
     std::unique_ptr<SpeakerGroupSettingsWindow> settingsWindow;
     void buttonClicked (juce::Button* button) override;

--- a/Source/sg_AudioProcessor.cpp
+++ b/Source/sg_AudioProcessor.cpp
@@ -106,7 +106,7 @@ void AudioProcessor::processOutputModifiersAndPeaks(SpeakerAudioBuffer & speaker
 //==============================================================================
 void AudioProcessor::processAudio(SourceAudioBuffer & sourceBuffer,
                                   SpeakerAudioBuffer & speakerBuffer,
-                                  juce::AudioBuffer<float> & stereoBuffer) noexcept [[clang::nonblocking]]
+                                  juce::AudioBuffer<float> & stereoBuffer) noexcept NONBLOCKING
 {
     // Skip if the user is editing the speaker setup.
     juce::ScopedTryLock const lock{ mLock };

--- a/Source/sg_ControlPanel.cpp
+++ b/Source/sg_ControlPanel.cpp
@@ -83,11 +83,11 @@ void GainsSubPanel::sliderMoved(float const value, SpatSlider * const slider)
 //==============================================================================
 SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
                                            MainContentComponent & mainContentComponent,
-                                           GrisLookAndFeel & lookAndFeel)
-    : SubPanelComponent(LayoutComponent::Orientation::horizontal, lookAndFeel)
+                                           GrisLookAndFeel & glaf)
+    : SubPanelComponent(LayoutComponent::Orientation::horizontal, glaf)
     , mControlPanel(controlPanel)
     , mMainContentComponent(mainContentComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
     , mAttenuationValues(getAttenuationValues())
 {
     auto const initLabel = [&](juce::Label & label,
@@ -95,7 +95,7 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
                                juce::Justification const justification = juce::Justification::centredTop) {
         label.setText(text, juce::dontSendNotification);
         label.setJustificationType(justification);
-        label.setColour(juce::Label::ColourIds::textColourId, lookAndFeel.getFontColour());
+        label.setColour(juce::Label::ColourIds::textColourId, glaf.getFontColour());
     };
 
     auto const initButton = [&](juce::Button & button, juce::String const & text, juce::String const & tooltip, bool isSpatModeRadioButton = true) {
@@ -113,7 +113,7 @@ SpatSettingsSubPanel::SpatSettingsSubPanel(ControlPanel & controlPanel,
     initLabel(mLeftLabel, "Left :", juce::Justification::topRight);
     initLabel(mRightLabel, "Right :", juce::Justification::topRight);
 
-    mAttenuationSettingsButton.setColour(juce::ToggleButton::ColourIds::textColourId, lookAndFeel.getFontColour());
+    mAttenuationSettingsButton.setColour(juce::ToggleButton::ColourIds::textColourId, glaf.getFontColour());
     mAttenuationSettingsButton.onClick = [this] {
         updateAttenuationState();
         updateLayout();
@@ -352,7 +352,7 @@ void SpatSettingsSubPanel::updateEnabledStereoRoutings()
     auto const rightId{ mRightCombo.getSelectedId() };
 
     jassert(mLeftCombo.getNumItems() == mRightCombo.getNumItems());
-    jassert(leftId == 0 && rightId == 0 || mLeftCombo.getSelectedId() != mRightCombo.getSelectedId());
+    jassert((leftId == 0 && rightId == 0) || mLeftCombo.getSelectedId() != mRightCombo.getSelectedId());
 
     for (int i{}; i < mLeftCombo.getNumItems(); ++i) {
         auto const itemId{ mLeftCombo.getItemId(i) };
@@ -483,9 +483,9 @@ SpatSettingsSubPanel::AttenuationValues SpatSettingsSubPanel::getAttenuationValu
 }
 
 //==============================================================================
-ControlPanel::ControlPanel(MainContentComponent & mainContentComponent, GrisLookAndFeel & lookAndFeel)
+ControlPanel::ControlPanel(MainContentComponent & mainContentComponent, GrisLookAndFeel & glaf)
     : mMainContentComponent(mainContentComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
 

--- a/Source/sg_DirectOutSelectorComponent.cpp
+++ b/Source/sg_DirectOutSelectorComponent.cpp
@@ -27,7 +27,7 @@ namespace gris
 DirectOutSelectorComponent::DirectOutSelectorComponent(tl::optional<output_patch_t> const & directOut,
                                                        std::shared_ptr<Choices> choices,
                                                        Listener & listener,
-                                                       SmallGrisLookAndFeel & lookAndFeel)
+                                                       SmallGrisLookAndFeel & glaf)
     : mListener(listener)
     , mChoices(std::move(choices))
     , mButton("", "Direct out")
@@ -36,8 +36,8 @@ DirectOutSelectorComponent::DirectOutSelectorComponent(tl::optional<output_patch
 
     addAndMakeVisible(mButton);
 
-    mButton.setColour(juce::Label::textColourId, lookAndFeel.getFontColour());
-    mButton.setLookAndFeel(&lookAndFeel);
+    mButton.setColour(juce::Label::textColourId, glaf.getFontColour());
+    mButton.setLookAndFeel(&glaf);
 
     setDirectOut(directOut);
 }

--- a/Source/sg_EditSpeakersWindow.cpp
+++ b/Source/sg_EditSpeakersWindow.cpp
@@ -48,31 +48,31 @@ LabelComboBoxWrapper::LabelComboBoxWrapper(GrisLookAndFeel & lookAndFeel) : Labe
 
 //==============================================================================
 EditSpeakersWindow::EditSpeakersWindow(juce::String const & name,
-                                       GrisLookAndFeel & lookAndFeel,
+                                       GrisLookAndFeel & glaf,
                                        MainContentComponent & mainContentComponent,
                                        juce::UndoManager& undoMan)
-    : DocumentWindow(name, lookAndFeel.getBackgroundColour(), allButtons)
+    : DocumentWindow(name, glaf.getBackgroundColour(), allButtons)
     , mMainContentComponent(mainContentComponent)
     , spatGrisData(mainContentComponent.getData())
-    , mLookAndFeel(lookAndFeel)
-    , mViewportWrapper(lookAndFeel)
-    , mRingSpeakers(lookAndFeel)
-    , mRingElevation(lookAndFeel)
-    , mRingRadius(lookAndFeel)
-    , mRingOffsetAngle(lookAndFeel)
-    , mPolyFaces(lookAndFeel)
-    , mPolyX(lookAndFeel)
-    , mPolyY(lookAndFeel)
-    , mPolyZ(lookAndFeel)
-    , mPolyRadius(lookAndFeel)
-    , mGridAlignment(lookAndFeel)
-    , mGridNumCols(lookAndFeel)
-    , mGridNumRows(lookAndFeel)
-    , mGridX(lookAndFeel)
-    , mGridY(lookAndFeel)
-    , mGridZ(lookAndFeel)
-    , mGridWidth(lookAndFeel)
-    , mGridHeight(lookAndFeel)
+    , mLookAndFeel(glaf)
+    , mViewportWrapper(glaf)
+    , mRingSpeakers(glaf)
+    , mRingElevation(glaf)
+    , mRingRadius(glaf)
+    , mRingOffsetAngle(glaf)
+    , mPolyFaces(glaf)
+    , mPolyX(glaf)
+    , mPolyY(glaf)
+    , mPolyZ(glaf)
+    , mPolyRadius(glaf)
+    , mGridAlignment(glaf)
+    , mGridNumCols(glaf)
+    , mGridNumRows(glaf)
+    , mGridX(glaf)
+    , mGridY(glaf)
+    , mGridZ(glaf)
+    , mGridWidth(glaf)
+    , mGridHeight(glaf)
     , mSpeakerSetupContainer(spatGrisData.appData.lastSpeakerSetup, spatGrisData.speakerSetup.speakerSetupValueTree, undoMan, [this]() { pushSelectionToMainComponent (); })
     , mFont(juce::FontOptions().withHeight(14.f))
     , undoManager (undoMan)
@@ -88,7 +88,7 @@ EditSpeakersWindow::EditSpeakersWindow(juce::String const & name,
     };
 
     setupButton(mAddSpeakerButton, "Add Speaker");
-    mAddSpeakerButton.setColour(juce::TextButton::buttonColourId, lookAndFeel.mImportantColor);
+    mAddSpeakerButton.setColour(juce::TextButton::buttonColourId, glaf.mImportantColor);
     setupButton(mSaveAsSpeakerSetupButton, "Save As...");
     setupButton(mSaveSpeakerSetupButton, "Save");
 
@@ -134,7 +134,7 @@ EditSpeakersWindow::EditSpeakersWindow(juce::String const & name,
     setupWrapper(&mRingRadius, "Distance", "Distance of the speakers from the center.", "1.0", 6, "0123456789.");
     setupWrapper(&mRingOffsetAngle, "Offset Angle", "Offset angle of the first speaker.", "0.0", 6, "-0123456789.");
     setupButton(mAddRingButton, "Add Ring");
-    mAddRingButton.setColour(juce::TextButton::buttonColourId, lookAndFeel.mImportantColor);
+    mAddRingButton.setColour(juce::TextButton::buttonColourId, glaf.mImportantColor);
 
     // Polyhedron of speakers.
     setupLabel(mPolyTitle, "Polyhedron parameters:");
@@ -156,7 +156,7 @@ EditSpeakersWindow::EditSpeakersWindow(juce::String const & name,
     setupWrapper(&mPolyZ, "Z", "Z position for the center of the polyhedron.", "0", 4, "-0123456789.");
     setupWrapper(&mPolyRadius, "Radius", "Radius for the polyhedron.", ".05", 4, "0123456789.");
     setupButton(mAddPolyButton, "Add Polyhedron");
-    mAddPolyButton.setColour(juce::TextButton::buttonColourId, lookAndFeel.mImportantColor);
+    mAddPolyButton.setColour(juce::TextButton::buttonColourId, glaf.mImportantColor);
 
     togglePolyhedraExtraWidgets();
 
@@ -196,7 +196,7 @@ EditSpeakersWindow::EditSpeakersWindow(juce::String const & name,
     setupWrapper(&mGridWidth, "Width", "Width of the speaker grid.", "2", 4, "0123456789.");
     setupWrapper(&mGridHeight, "Height", "Height of the speaker grid.", "1", 4, "0123456789.");
     setupButton(mAddGridButton, "Add Grid");
-    mAddGridButton.setColour(juce::TextButton::buttonColourId, lookAndFeel.mImportantColor);
+    mAddGridButton.setColour(juce::TextButton::buttonColourId, glaf.mImportantColor);
 
     toggleGridWidgets();
 
@@ -496,8 +496,7 @@ void EditSpeakersWindow::buttonClicked(juce::Button * button)
             };
         }
 
-        auto const getSpeakerPosition = [this](int i) -> Position {
-            const auto numFaces = mPolyFaces.getSelectionAsInt();
+        auto const getSpeakerPosition = [this, &numFaces](int i) -> Position {
             const auto radius = mPolyRadius.getTextAs<float>();
 
             using Vec3 = std::array<float, 3>;
@@ -513,7 +512,7 @@ void EditSpeakersWindow::buttonClicked(juce::Button * button)
                     = { Vec3{ 1.f, 1.f, 1.f }, { 1.f, 1.f, -1.f },  { 1.f, -1.f, 1.f },  { 1.f, -1.f, -1.f },
                         { -1.f, 1.f, 1.f },    { -1.f, 1.f, -1.f }, { -1.f, -1.f, 1.f }, { -1.f, -1.f, -1.f } };
 
-                static const std::array<Vec3, 12> dodecahedron = {
+                static constexpr std::array<Vec3, 12> dodecahedron = {
                     Vec3{ -1.15217f, 0.f, 1.51342f }, { 0.57984f, 1.f, 1.51053f },   { 0.57984f, -1.f, 1.51053f },
                     { -0.93358f, -1.618f, 0.35837f }, { -1.86890f, 0.f, -0.35374f }, { -0.93358f, 1.618f, 0.35837f },
                     { 0.93358f, 1.618f, -0.35837f },  { 1.86890f, 0.f, 0.35374f },   { 0.93358f, -1.618f, -0.35837f },
@@ -546,12 +545,12 @@ void EditSpeakersWindow::buttonClicked(juce::Button * button)
                 }
             }();
 
-            if (i < 0 || i >= vertices.size()) {
+            if (i < 0 || i >= static_cast<int>(vertices.size())) {
                 jassertfalse;
                 return Position{ { 0, 0, 0 } };
             }
 
-            const auto & curVertex = vertices[i];
+            const auto & curVertex = vertices[static_cast<size_t>(i)];
             const auto norm = std::hypot(curVertex[0], curVertex[1], curVertex[2]);
 
             // Normalize and scale to radius
@@ -733,7 +732,7 @@ void EditSpeakersWindow::textEditorFocusLost(juce::TextEditor & textEditor)
     } else if (&textEditor == &mGridX.editor
                || &textEditor == &mGridY.editor
                || &textEditor == &mGridZ.editor) {
-        
+
         clampGridXYZ(textEditor);
     } else if (&textEditor == &mGridWidth.editor
                || &textEditor == &mGridHeight.editor) {

--- a/Source/sg_FlatViewWindow.cpp
+++ b/Source/sg_FlatViewWindow.cpp
@@ -180,7 +180,7 @@ void FlatViewWindow::drawSource(juce::Graphics & g,
                                 ViewportSourceData const & sourceData,
                                 SpatMode const spatMode) const
 {
-    static constexpr auto SOURCE_DIAMETER_INT{ narrow<int>(SOURCE_DIAMETER) };
+    static const auto SOURCE_DIAMETER_INT{ narrow<int>(SOURCE_DIAMETER) };
 
     if (sourceData.colour.getAlpha() == 0) {
         return;

--- a/Source/sg_FlatViewWindow.cpp
+++ b/Source/sg_FlatViewWindow.cpp
@@ -189,15 +189,15 @@ void FlatViewWindow::drawSource(juce::Graphics & g,
     auto const fieldSize{ narrow<float>(getWidth()) };
     auto const realSize = fieldSize - SOURCE_DIAMETER;
 
-    auto const getSourcePosition = [&](ViewportSourceData const & sourceData) {
+    auto const getSourcePosition = [&](ViewportSourceData const & srcData) {
         switch (spatMode) {
         case SpatMode::vbap: {
-            auto const & vector{ sourceData.position.getPolar() };
+            auto const & vector{ srcData.position.getPolar() };
             auto const radius{ 1.0f - vector.elevation / HALF_PI };
             return juce::Point<float>{ std::cos(vector.azimuth.get()), -std::sin(vector.azimuth.get()) } * radius;
         }
         case SpatMode::mbap: {
-            auto const & position{ sourceData.position.getCartesian() };
+            auto const & position{ srcData.position.getCartesian() };
             return juce::Point<float>{ position.x, -position.y } / MBAP_EXTENDED_RADIUS;
         }
         case SpatMode::hybrid:

--- a/Source/sg_GeneralMuteButton.cpp
+++ b/Source/sg_GeneralMuteButton.cpp
@@ -40,8 +40,8 @@ auto const MOUSE_DOWN_BACKGROUND_COLOR{ juce::Colours::black.withAlpha(0.2f) };
 } // namespace
 
 //==============================================================================
-GeneralMuteButton::GeneralMuteButton(Listener & listener, GrisLookAndFeel & lookAndFeel)
-    : mLookAndFeel(lookAndFeel)
+GeneralMuteButton::GeneralMuteButton(Listener & listener, GrisLookAndFeel & glaf)
+    : mLookAndFeel(glaf)
     , mListener(listener)
 {
     JUCE_ASSERT_MESSAGE_THREAD;

--- a/Source/sg_HybridSpatModeSelectorComponent.cpp
+++ b/Source/sg_HybridSpatModeSelectorComponent.cpp
@@ -24,10 +24,10 @@ namespace gris
 //==============================================================================
 HybridSpatModeSelectorComponent::HybridSpatModeSelectorComponent(SpatMode const hybridSpatMode,
                                                                  Listener & listener,
-                                                                 SmallGrisLookAndFeel & lookAndFeel)
+                                                                 SmallGrisLookAndFeel & glaf)
     : mListener(listener)
-    , mDomeButton(true, "dom", "Set this source to DOME mode", *this, lookAndFeel)
-    , mCubeButton(true, "cub", "Set this source to CUBE mode", *this, lookAndFeel)
+    , mDomeButton(true, "dom", "Set this source to DOME mode", *this, glaf)
+    , mCubeButton(true, "cub", "Set this source to CUBE mode", *this, glaf)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
 

--- a/Source/sg_InfoPanel.cpp
+++ b/Source/sg_InfoPanel.cpp
@@ -34,13 +34,13 @@ auto const COLOR_2 = juce::Colours::blue.withBrightness(0.2f).withSaturation(0.2
 namespace gris
 {
 //==============================================================================
-InfoPanel::InfoPanel(MainContentComponent & mainContentComponent, GrisLookAndFeel const & lookAndFeel)
+InfoPanel::InfoPanel(MainContentComponent & mainContentComponent, GrisLookAndFeel const & glaf)
     : mMainContentComponent(mainContentComponent)
 
 {
     auto const primeLabel = [&](juce::Label & label) {
         label.setJustificationType(juce::Justification::centred);
-        label.setColour(juce::Label::ColourIds::textColourId, lookAndFeel.getFontColour());
+        label.setColour(juce::Label::ColourIds::textColourId, glaf.getFontColour());
         label.addMouseListener(this, false);
         addAndMakeVisible(label);
     };

--- a/Source/sg_LayoutComponent.cpp
+++ b/Source/sg_LayoutComponent.cpp
@@ -17,6 +17,8 @@
  along with SpatGRIS.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
+
 #include "sg_LayoutComponent.hpp"
 
 #include "sg_GrisLookAndFeel.hpp"
@@ -213,7 +215,7 @@ int LayoutComponent::Section::computeSectionHeight(Orientation const orientation
 LayoutComponent::LayoutComponent(Orientation const orientation,
                                  bool const isHorizontalScrollable,
                                  bool const isVerticalScrollable,
-                                 GrisLookAndFeel & lookAndFeel) noexcept
+                                 GrisLookAndFeel & glaf) noexcept
     : mOrientation(orientation)
     , mIsHorizontalScrollable(isHorizontalScrollable)
     , mIsVerticalScrollable(isVerticalScrollable)
@@ -223,9 +225,9 @@ LayoutComponent::LayoutComponent(Orientation const orientation,
     mViewport.setScrollBarsShown(isVerticalScrollable, isHorizontalScrollable);
     mViewport.setScrollBarThickness(SCROLL_BAR_WIDTH);
     mViewport.getHorizontalScrollBar().setColour(juce::ScrollBar::ColourIds::thumbColourId,
-                                                 lookAndFeel.getScrollBarColour());
+                                                 glaf.getScrollBarColour());
     mViewport.getVerticalScrollBar().setColour(juce::ScrollBar::ColourIds::thumbColourId,
-                                               lookAndFeel.getScrollBarColour());
+                                               glaf.getScrollBarColour());
     mViewport.setViewedComponent(new juce::Component{}, true);
     addAndMakeVisible(mViewport);
 }
@@ -304,7 +306,7 @@ void LayoutComponent::resized()
         0.0f,
         std::plus(),
         [](Section const & section) { return section.mRelativeSize; }) };
-    auto const pixelsPerRelativeUnit{ totalRelativeUnits == 0.0f ? 0.0f
+    auto const pixelsPerRelativeUnit{ std::fpclassify(totalRelativeUnits) == FP_ZERO ? 0.0f
                                                                  : narrow<float>(spaceToShare) / totalRelativeUnits };
 
     if (mOrientation == Orientation::horizontal) {

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -794,7 +794,7 @@ void MainContentComponent::handleShowSpeakerViewWindow()
     }
 
     // SpeakerView camera position
-    auto const & camPos{ mSpeakerViewComponent->getCameraPosition().getPolar() };
+    auto const camPos{ mSpeakerViewComponent->getCameraPosition().getPolar() };
     auto azi = -camPos.azimuth; // azimuth is inverted in SpeakerView
     auto aziDeg = juce::radiansToDegrees(azi.get());
     auto elev = camPos.elevation;
@@ -2005,8 +2005,8 @@ void MainContentComponent::setLegacySourcePosition(source_index_t const sourceIn
     auto const correctedPosition{ getCorrectedPosition() };
     auto & source{ mData.project.sources[sourceIndex] };
 
-    if (correctedPosition == source.position && newAzimuthSpan == source.azimuthSpan
-        && newZenithSpan == source.zenithSpan) {
+    if (correctedPosition == source.position && juce::approximatelyEqual(newAzimuthSpan, source.azimuthSpan)
+        && juce::approximatelyEqual(newZenithSpan, source.zenithSpan)) {
         return;
     }
 
@@ -2056,7 +2056,7 @@ void MainContentComponent::setSourcePosition(source_index_t const sourceIndex,
         break;
     }
 
-    if (position == source.position && azimuthSpan == source.azimuthSpan && zenithSpan == source.zenithSpan) {
+    if (position == source.position && juce::approximatelyEqual(azimuthSpan, source.azimuthSpan) && juce::approximatelyEqual(zenithSpan, source.zenithSpan)) {
         return;
     }
 

--- a/Source/sg_MainComponent.cpp
+++ b/Source/sg_MainComponent.cpp
@@ -2412,6 +2412,13 @@ void MainContentComponent::refreshSpatAlgorithm()
                                                    "speakers not to be more than 170 degrees apart from each others.\n",
                                                    "Ok",
                                                    this);
+          break;
+        case AbstractSpatAlgorithm::Error::failedToSpawnThreadpool:
+            juce::AlertWindow::showMessageBoxAsync(juce::AlertWindow::AlertIconType::InfoIcon,
+                                                   "Disabled spatialization",
+                                                   "Failed to create threadpool.",
+                                                   "Ok",
+                                                   this);
             break;
         default:
             jassertfalse;

--- a/Source/sg_MuteSoloComponent.cpp
+++ b/Source/sg_MuteSoloComponent.cpp
@@ -23,10 +23,10 @@ namespace gris
 {
 //==============================================================================
 MuteSoloComponent::MuteSoloComponent(Listener & listener,
-                                     GrisLookAndFeel & lookAndFeel,
+                                     GrisLookAndFeel & glaf,
                                      SmallGrisLookAndFeel & smallLookAndFeel)
     : mListener(listener)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
     , mSmallLookAndFeel(smallLookAndFeel)
 {
     JUCE_ASSERT_MESSAGE_THREAD;

--- a/Source/sg_OscMonitor.cpp
+++ b/Source/sg_OscMonitor.cpp
@@ -105,8 +105,8 @@ void OscMonitorComponent::resized()
 //==============================================================================
 OscMonitorWindow::OscMonitorWindow(LogBuffer & logBuffer,
                                    MainContentComponent & mainContentComponent,
-                                   GrisLookAndFeel & lookAndFeel)
-    : DocumentWindow("OSC monitor", lookAndFeel.getBackgroundColour(), allButtons)
+                                   GrisLookAndFeel & glaf)
+    : DocumentWindow("OSC monitor", glaf.getBackgroundColour(), allButtons)
     , mMainContentComponent(mainContentComponent)
     , mComponent(logBuffer)
 {

--- a/Source/sg_PlayerWindow.cpp
+++ b/Source/sg_PlayerWindow.cpp
@@ -25,11 +25,11 @@ namespace gris
 {
 //==============================================================================
 ThumbnailComp::ThumbnailComp(PlayerComponent & playerComponent,
-                             GrisLookAndFeel & lookAndFeel,
+                             GrisLookAndFeel & glaf,
                              juce::OwnedArray<juce::AudioTransportSource> & transportSources,
                              juce::AudioFormatManager & manager)
     : mPlayerComponent(playerComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
     , mTransportSources(transportSources)
     , mManager(manager)
 {
@@ -535,11 +535,11 @@ void PlayerComponent::setTimeCode(double const timeInSec)
 }
 
 //==============================================================================
-PlayerWindow::PlayerWindow(MainContentComponent & mainContentComponent, GrisLookAndFeel & lookAndFeel)
-    : DocumentWindow("SpatGRIS Player", lookAndFeel.getBackgroundColour(), allButtons)
+PlayerWindow::PlayerWindow(MainContentComponent & mainContentComponent, GrisLookAndFeel & glaf)
+    : DocumentWindow("SpatGRIS Player", glaf.getBackgroundColour(), allButtons)
     , mMainContentComponent(mainContentComponent)
-    , mLookAndFeel(lookAndFeel)
-    , mPlayerComponent(mainContentComponent, lookAndFeel)
+    , mLookAndFeel(glaf)
+    , mPlayerComponent(mainContentComponent, glaf)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
 

--- a/Source/sg_PlayerWindow.cpp
+++ b/Source/sg_PlayerWindow.cpp
@@ -214,9 +214,9 @@ int ThumbnailComp::getNumSources() const
 }
 
 //==============================================================================
-PlayerComponent::PlayerComponent(MainContentComponent & mainContentComponent, GrisLookAndFeel & lookAndFeel)
+PlayerComponent::PlayerComponent(MainContentComponent & mainContentComponent, GrisLookAndFeel & glaf)
     : mMainContentComponent(mainContentComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
 {
     mLoadWavFilesAndSpeakerSetupButton.setButtonText("Load audio files and Speaker setup folder");
     mSavePlayerProjectButton.setButtonText("Save Player Project");

--- a/Source/sg_PrepareToRecordWindow.cpp
+++ b/Source/sg_PrepareToRecordWindow.cpp
@@ -40,9 +40,9 @@ using flags = juce::FileBrowserComponent::FileChooserFlags;
 PrepareToRecordComponent::PrepareToRecordComponent(juce::File const & recordingDirectory,
                                                    RecordingOptions const & recordingOptions,
                                                    MainContentComponent & mainContentComponent,
-                                                   GrisLookAndFeel & lookAndFeel)
+                                                   GrisLookAndFeel & glaf)
     : mMainContentComponent(mainContentComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
 
@@ -303,10 +303,10 @@ RecordingFormat PrepareToRecordComponent::getSelectedFormat() const
 PrepareToRecordWindow::PrepareToRecordWindow(juce::File const & recordingDirectory,
                                              RecordingOptions const & recordingOptions,
                                              MainContentComponent & mainContentComponent,
-                                             GrisLookAndFeel & lookAndFeel)
-    : DocumentWindow("Start recording", lookAndFeel.getBackgroundColour(), closeButton)
+                                             GrisLookAndFeel & glaf)
+    : DocumentWindow("Start recording", glaf.getBackgroundColour(), closeButton)
     , mMainContentComponent(mainContentComponent)
-    , mContentComponent(recordingDirectory, recordingOptions, mainContentComponent, lookAndFeel)
+    , mContentComponent(recordingDirectory, recordingOptions, mainContentComponent, glaf)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
 

--- a/Source/sg_RecordButton.cpp
+++ b/Source/sg_RecordButton.cpp
@@ -44,13 +44,13 @@ auto const MOUSE_DOWN_BACKGROUND_COLOR{ juce::Colours::black.withAlpha(0.2f) };
 } // namespace
 
 //==============================================================================
-RecordButton::RecordButton(Listener & listener, GrisLookAndFeel & lookAndFeel) : mListener(listener)
+RecordButton::RecordButton(Listener & listener, GrisLookAndFeel & glaf) : mListener(listener)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
     SettableTooltipClient::setTooltip("Record audio to disk");
 
     mRecordedTime.setJustificationType(juce::Justification::centred);
-    mRecordedTime.setColour(juce::Label::ColourIds::textColourId, lookAndFeel.getFontColour());
+    mRecordedTime.setColour(juce::Label::ColourIds::textColourId, glaf.getFontColour());
     addChildComponent(mRecordedTime);
 }
 

--- a/Source/sg_SettingsWindow.cpp
+++ b/Source/sg_SettingsWindow.cpp
@@ -53,10 +53,10 @@ bool isNotPowerOfTwo(int const value)
 } // namespace
 
 //==============================================================================
-SettingsComponent::SettingsComponent(MainContentComponent & parent, SpeakerViewComponent & sVComponent, GrisLookAndFeel & lookAndFeel)
+SettingsComponent::SettingsComponent(MainContentComponent & parent, SpeakerViewComponent & sVComponent, GrisLookAndFeel & glaf)
     : mMainContentComponent(parent)
     , mSVComponent(sVComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
 {
 
     mInitialOSCPort = parent.getOscPort();

--- a/Source/sg_SmallToggleButton.cpp
+++ b/Source/sg_SmallToggleButton.cpp
@@ -28,7 +28,7 @@ SmallToggleButton::SmallToggleButton(bool const isToggle,
                                      juce::String const & text,
                                      juce::String const & toolTip,
                                      Listener & listener,
-                                     SmallGrisLookAndFeel & lookAndFeel)
+                                     SmallGrisLookAndFeel & sglaf)
     : mListener(listener)
 
     , mLabel("", text)
@@ -37,11 +37,11 @@ SmallToggleButton::SmallToggleButton(bool const isToggle,
     JUCE_ASSERT_MESSAGE_THREAD;
 
     auto const initColors = [&](Component & component) {
-        component.setLookAndFeel(&lookAndFeel);
-        component.setColour(juce::Label::textColourId, lookAndFeel.getFontColour());
-        component.setColour(juce::TextButton::textColourOnId, lookAndFeel.getFontColour());
-        component.setColour(juce::TextButton::textColourOffId, lookAndFeel.getFontColour());
-        component.setColour(juce::TextButton::buttonColourId, lookAndFeel.getBackgroundColour());
+        component.setLookAndFeel(&sglaf);
+        component.setColour(juce::Label::textColourId, sglaf.getFontColour());
+        component.setColour(juce::TextButton::textColourOnId, sglaf.getFontColour());
+        component.setColour(juce::TextButton::textColourOffId, sglaf.getFontColour());
+        component.setColour(juce::TextButton::buttonColourId, sglaf.getBackgroundColour());
         addAndMakeVisible(component);
     };
 

--- a/Source/sg_SourceIdButton.cpp
+++ b/Source/sg_SourceIdButton.cpp
@@ -25,10 +25,10 @@ namespace gris
 SourceIdButton::SourceIdButton(source_index_t const sourceIndex,
                                juce::Colour const color,
                                Listener & listener,
-                               SmallGrisLookAndFeel & lookAndFeel)
+                               SmallGrisLookAndFeel & glaf)
     : mListener(listener)
 
-    , mButton(false, juce::String{ sourceIndex.get() }, "Change color", *this, lookAndFeel)
+    , mButton(false, juce::String{ sourceIndex.get() }, "Change color", *this, glaf)
     , mSourceIndexCallBox{ nullptr }
 {
     JUCE_ASSERT_MESSAGE_THREAD;

--- a/Source/sg_SourceSliceComponent.cpp
+++ b/Source/sg_SourceSliceComponent.cpp
@@ -30,9 +30,9 @@ SourceSliceComponent::SourceSliceComponent(source_index_t const sourceIndex,
                                            juce::Colour const colour,
                                            std::shared_ptr<DirectOutSelectorComponent::Choices> directOutChoices,
                                            Listener & owner,
-                                           GrisLookAndFeel & lookAndFeel,
+                                           GrisLookAndFeel & glaf,
                                            SmallGrisLookAndFeel & smallLookAndFeel)
-    : AbstractSliceComponent(lookAndFeel, smallLookAndFeel)
+    : AbstractSliceComponent(glaf, smallLookAndFeel)
     , mOwner(owner)
     , mSourceIndex(sourceIndex)
     , mIdButton(sourceIndex, colour, *this, smallLookAndFeel)

--- a/Source/sg_SpatSlider.cpp
+++ b/Source/sg_SpatSlider.cpp
@@ -41,14 +41,14 @@ SpatSlider::SpatSlider(float const minValue,
                        juce::String const & label,
                        juce::String const & tooltip,
                        Listener & listener,
-                       GrisLookAndFeel & lookAndFeel)
+                       GrisLookAndFeel & glaf)
     : mListener(listener)
     , mLabel("", label)
     , mSlider(juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, juce::Slider::TextEntryBoxPosition::TextBoxBelow)
 {
     JUCE_ASSERT_MESSAGE_THREAD;
 
-    mLabel.setColour(juce::Label::ColourIds::textColourId, lookAndFeel.getFontColour());
+    mLabel.setColour(juce::Label::ColourIds::textColourId, glaf.getFontColour());
     mLabel.setJustificationType(juce::Justification::centredTop);
     mLabel.setInterceptsMouseClicks(false, false);
 
@@ -60,7 +60,7 @@ SpatSlider::SpatSlider(float const minValue,
     mSlider.setTooltip(tooltip);
     mSlider.setRotaryParameters(juce::MathConstants<float>::pi * 1.3f, juce::MathConstants<float>::pi * 2.7f, true);
     mSlider.setTextBoxStyle(juce::Slider::TextBoxBelow, false, ENTRY_BOX_WIDTH, ENTRY_BOX_HEIGHT);
-    mSlider.setLookAndFeel(&lookAndFeel);
+    mSlider.setLookAndFeel(&glaf);
 
     addAndMakeVisible(mSlider);
 }

--- a/Source/sg_SpeakerIdButton.cpp
+++ b/Source/sg_SpeakerIdButton.cpp
@@ -26,10 +26,10 @@ namespace gris
 //==============================================================================
 SpeakerIdButton::SpeakerIdButton(output_patch_t const outputPatch,
                                  Listener & listener,
-                                 SmallGrisLookAndFeel & lookAndFeel)
+                                 SmallGrisLookAndFeel & glaf)
     : mListener(listener)
-    , mLookAndFeel(lookAndFeel)
-    , mButton(false, juce::String{ outputPatch.get() }, "Select speaker", *this, lookAndFeel)
+    , mLookAndFeel(glaf)
+    , mButton(false, juce::String{ outputPatch.get() }, "Select speaker", *this, glaf)
 {
     addAndMakeVisible(mButton);
 }

--- a/Source/sg_SpeakerSliceComponent.cpp
+++ b/Source/sg_SpeakerSliceComponent.cpp
@@ -49,9 +49,9 @@ void SpeakerSliceComponent::muteSoloButtonClicked(SliceState const state)
 //==============================================================================
 SpeakerSliceComponent::SpeakerSliceComponent(output_patch_t const outputPatch,
                                              Listener & owner,
-                                             GrisLookAndFeel & lookAndFeel,
+                                             GrisLookAndFeel & glaf,
                                              SmallGrisLookAndFeel & smallLookAndFeel)
-    : AbstractSliceComponent(lookAndFeel, smallLookAndFeel)
+    : AbstractSliceComponent(glaf, smallLookAndFeel)
     , mOwner(owner)
     , mOutputPatch(outputPatch)
     , mIdButton(outputPatch, *this, smallLookAndFeel)

--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -482,7 +482,7 @@ void SpeakerViewComponent::listenUDP(juce::DatagramSocket& socket)
     auto packetSize = socket.read(receiveBuffer, mMaxBufferSize, false, senderAddress, senderPort);
 
     if (packetSize > 0) {
-        juce::String receivedData(receiveBuffer, packetSize);
+        juce::String receivedData(receiveBuffer, static_cast<size_t>(packetSize));
         juce::var jsonResult;
         auto res = juce::JSON::parse(receivedData, jsonResult);
 

--- a/Source/sg_StereoSliceComponent.cpp
+++ b/Source/sg_StereoSliceComponent.cpp
@@ -23,9 +23,9 @@ namespace gris
 {
 //==============================================================================
 StereoSliceComponent::StereoSliceComponent(juce::String const & id,
-                                           GrisLookAndFeel & lookAndFeel,
+                                           GrisLookAndFeel & glaf,
                                            SmallGrisLookAndFeel & smallLookAndFeel)
-    : AbstractSliceComponent(lookAndFeel, smallLookAndFeel)
+    : AbstractSliceComponent(glaf, smallLookAndFeel)
     , mIdButton(false, id, "", *this, smallLookAndFeel)
 {
     mLayout.addSection(mIdButton).withFixedSize(SLICES_ID_BUTTON_HEIGHT);

--- a/Source/sg_SubPanelComponent.cpp
+++ b/Source/sg_SubPanelComponent.cpp
@@ -32,9 +32,9 @@ constexpr auto OFFSET{ INNER_PADDING / 2 };
 namespace gris
 {
 //==============================================================================
-SubPanelComponent::SubPanelComponent(LayoutComponent::Orientation const orientation, GrisLookAndFeel & lookAndFeel)
-    : mLookAndFeel(lookAndFeel)
-    , mLayout(orientation, false, false, lookAndFeel)
+SubPanelComponent::SubPanelComponent(LayoutComponent::Orientation const orientation, GrisLookAndFeel & glaf)
+    : mLookAndFeel(glaf)
+    , mLayout(orientation, false, false, glaf)
 {
     addAndMakeVisible(mLayout);
 }

--- a/Source/sg_TitledComponent.cpp
+++ b/Source/sg_TitledComponent.cpp
@@ -26,10 +26,10 @@ namespace gris
 //==============================================================================
 TitledComponent::TitledComponent(juce::String title,
                                  MinSizedComponent * contentComponent,
-                                 GrisLookAndFeel & lookAndFeel)
+                                 GrisLookAndFeel & glaf)
     : mTitle(std::move(title))
     , mContentComponent(contentComponent)
-    , mLookAndFeel(lookAndFeel)
+    , mLookAndFeel(glaf)
 {
     addAndMakeVisible(mContentComponent);
 }


### PR DESCRIPTION
Fixes a bunch of clang and gcc warning. Depends on the related AlgoGRIS PR.

More details on the remaining warnings:
- Some remaining warnings are located in dependencies
- Float equality warnings are still in project data serialization and deserialization. I think == is ok in this case
- There is a deprecation for an audio writer (`createWriterFor`) in juce that I left there since I don't know the impact of changing to the non deprecated method.