### PR TITLE
Disable fast math

### DIFF
--- a/SpatGRIS.jucer
+++ b/SpatGRIS.jucer
@@ -386,9 +386,9 @@
                applicationCategory="public.app-category.music">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" osxCompatibility="10.13 SDK" isDebug="1" optimisation="1"
-                       targetName="SpatGRIS" fastMath="1" macOSDeploymentTarget="10.13"/>
+                       targetName="SpatGRIS" fastMath="0" macOSDeploymentTarget="10.13"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="SpatGRIS"
-                       osxArchitecture="Native" fastMath="1"/>
+                       osxArchitecture="Native" fastMath="0"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_core" path="submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/modules"/>
@@ -437,8 +437,9 @@
     <VS2022 targetFolder="Builds/VisualStudio2022" bigIcon="NHix3D">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" headerPath="C:\dev\ASIO_SDK\common"
-                       fastMath="1"/>
-        <CONFIGURATION isDebug="0" name="Release" headerPath="C:\dev\ASIO_SDK\common"/>
+                       fastMath="0"/>
+        <CONFIGURATION isDebug="0" name="Release" headerPath="C:\dev\ASIO_SDK\common"
+                       fastMath="0"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_osc" path="submodules/AlgoGRIS/submodules/StructGRIS/submodules/JUCE/modules"/>


### PR DESCRIPTION
This disables compiling SpatGRIS with `-fast-math` optimisations on debug build for windows and on debug and release builds for mac.

These optimisation can lead to undefined behaviours and to wrong results, especially with code explicitly checking for `NaN` or `infinity` floating point values. Both internal JUCE code and SpatGRIS's own code explicitly use and checks for `inifinity` which makes the optimisation dangerous.

I have run benchmarks with fast-maths enabled and disabled using clang in release mode and it looks like the performance gains are very minor; on the order of <1% on most algorithms except hrtf which gets something like a 7% performance boost.

Here are the results of my benchmark (run on a somewhat powerful linux desktop)

```vbap fast math               vbap no fast math                   
count  50.000000             count  50.000000                    
mean    1.532662             mean    1.537231                    
std     0.004019             std     0.003680                    
min     1.529820             min     1.534130                    
25%     1.530873             25%     1.535125                    
50%     1.531440             50%     1.536065                    
75%     1.532725             75%     1.538190                    
max     1.549720             max     1.557500                    
                                                                 
parallel vbap fast math      parallel vbap no fast math          
count  50.000000             count  50.000000                    
mean    0.295985             mean    0.299284                    
std     0.017297             std     0.015585                    
min     0.281038             min     0.287754                    
25%     0.285224             25%     0.290814                    
50%     0.287991             50%     0.293749                    
75%     0.299892             75%     0.300613                    
max     0.357896             max     0.372819                    
                                                                 
mbap fast math               mbap no fast math                   
count  50.000000             count  50.000000                    
mean    7.589188             mean    7.603576                    
std     0.014303             std     0.020208                    
min     7.577680             min     7.585990                    
25%     7.581100             25%     7.592380                    
50%     7.584435             50%     7.596400                    
75%     7.590455             75%     7.604995                    
max     7.656560             max     7.671730                    
                                                                 
parallel mbap fast math      parallel mbap no fast math          
count  50.000000             count  50.000000                    
mean    1.624945             mean    1.549841                    
std     0.180057             std     0.035719                    
min     1.488420             min     1.486850                    
25%     1.542132             25%     1.523858                    
50%     1.565795             50%     1.541615                    
75%     1.635487             75%     1.574812                    
max     2.525610             max     1.625570                    
                                                                 
hybrid fast-math             hybrid no fast math                 
count  10.000000             count  50.000000                    
mean    4.681814             mean    4.679941                    
std     0.014173             std     0.014798                    
min     4.666100             min     4.669270                    
25%     4.667217             25%     4.672315                    
50%     4.685500             50%     4.676150                    
75%     4.690143             75%     4.680175                    
max     4.706740             max     4.765630                    
                                                                 
parallel hybrid fast-math    parallel hybrid no fast math        
count  10.000000             count  50.000000                    
mean    2.209222             mean    2.108789                    
std     0.309252             std     0.108426                    
min     1.902660             min     1.874610                    
25%     2.037780             25%     2.013057                    
50%     2.121475             50%     2.129380                    
75%     2.208788             75%     2.180450                    
max     2.894730             max     2.284890                    
                                                                 
hrtf fast math               hrtf no fast math                   
count  50.000000             count  50.000000                    
mean   13.831008             mean   14.509796                    
std     0.096739             std     0.090396                    
min    13.700200             min    14.363300                    
25%    13.748825             25%    14.437575                    
50%    13.818950             50%    14.486750                    
75%    13.890675             75%    14.593200                    
max    14.131800             max    14.666700                    
                                                                 
stereo fast math             stereo no fast math                 
count  50.000000             count  50.000000                    
mean    1.000679             mean    0.999744                    
std     0.002099             std     0.001701                    
min     0.998953             min     0.998826                    
25%     0.999084             25%     0.998964                    
50%     0.999695             50%     0.999359                    
75%     1.001495             75%     0.999727                    
max     1.006840             max     1.009510                    

```