### PR TITLE
Fix OSC input port, multicore DSP toggle and extra speakerview ports not being updated on project load

### DIFF
--- a/Source/sg_SpeakerViewComponent.cpp
+++ b/Source/sg_SpeakerViewComponent.cpp
@@ -68,17 +68,11 @@ SpeakerViewComponent::SpeakerViewComponent(MainContentComponent & mainContentCom
     , mUDPDefaultOutputAddress(localhost)
 {
 
-    const auto uDPExtraOutputPort = mainContentComponent.getData().project.standaloneSpeakerViewOutputPort;
-    const auto uDPExtraOutputAddress = mainContentComponent.getData().project.standaloneSpeakerViewOutputAddress;
+    const auto extraUDPOutputPort = mainContentComponent.getData().project.standaloneSpeakerViewOutputPort;
+    const auto extraUDPOutputAddress = mainContentComponent.getData().project.standaloneSpeakerViewOutputAddress;
     const auto extraUDPInputPort = mainContentComponent.getData().project.standaloneSpeakerViewInputPort;
-    if (extraUDPInputPort) {
-        setExtraUDPInputPort(*extraUDPInputPort);
-    }
 
-    // If we have an address and port, enable sending to the extra standalone SpeakerView.
-    if (uDPExtraOutputPort && uDPExtraOutputAddress) {
-        setExtraUDPOutput(*uDPExtraOutputPort, *uDPExtraOutputAddress);
-    }
+    initExtraPorts(extraUDPInputPort, extraUDPOutputPort, extraUDPOutputAddress);
 
     mUdpReceiverSocket.bindToPort(DEFAULT_UDP_INPUT_PORT);
 }
@@ -87,6 +81,22 @@ SpeakerViewComponent::SpeakerViewComponent(MainContentComponent & mainContentCom
 SpeakerViewComponent::~SpeakerViewComponent()
 {
     stopTimer();
+}
+
+void SpeakerViewComponent::initExtraPorts(tl::optional<int> extraUDPInputPort, tl::optional<int>  extraUDPOutputPort, tl::optional<juce::String> extraUDPOutputAddress)
+{
+    if (extraUDPInputPort) {
+        setExtraUDPInputPort(*extraUDPInputPort);
+    } else {
+        disableExtraUDPInput();
+    }
+
+    // If we have an address and port, enable sending to the extra standalone SpeakerView.
+    if (extraUDPOutputPort && extraUDPOutputAddress) {
+        setExtraUDPOutput(*extraUDPOutputPort, *extraUDPOutputAddress);
+    } else {
+        disableExtraUDPOutput();
+    }
 }
 
 bool SpeakerViewComponent::setExtraUDPInputPort(int const port)

--- a/Source/sg_SpeakerViewComponent.hpp
+++ b/Source/sg_SpeakerViewComponent.hpp
@@ -140,6 +140,12 @@ public:
     tl::optional<int> getExtraUDPOutputPort() const;
     tl::optional<juce::String> getExtraUDPOutputAddress() const;
 
+
+    /**
+     * Manages all the extra ports if you pass it the data contained in the project data.
+     */
+    void initExtraPorts(tl::optional<int> uDPExtraInputPort, tl::optional<int> uDPExtraOutputPort, tl::optional<juce::String> uDPExtraOutputAddress);
+
     void disableExtraUDPOutput();
     void disableExtraUDPInput();
     /**


### PR DESCRIPTION
These configurations were not updated when loading a new project, they are now.

Fixes the bug outlined in this issue : https://github.com/GRIS-UdeM/SpatGRIS/issues/548